### PR TITLE
fix: include user email in YooKassa payment metadata

### DIFF
--- a/backend/open_webui/test/apps/webui/routers/test_billing_topup.py
+++ b/backend/open_webui/test/apps/webui/routers/test_billing_topup.py
@@ -733,6 +733,7 @@ class TestBillingTopup(AbstractPostgresTest):
         assert fake_client.last_amount == Decimal("199.00")
         assert isinstance(fake_client.last_metadata, dict)
         assert fake_client.last_metadata.get("wallet_id") == wallet.id
+        assert fake_client.last_metadata.get("user_email") == "topup-user@example.com"
         assert isinstance(fake_client.last_receipt, dict)
         customer = fake_client.last_receipt.get("customer")
         assert isinstance(customer, dict)

--- a/backend/open_webui/test/apps/webui/utils/test_billing_service_core.py
+++ b/backend/open_webui/test/apps/webui/utils/test_billing_service_core.py
@@ -79,7 +79,11 @@ class TestBillingServiceCore:
         )
 
         class FakeYooKassaClient:
+            def __init__(self) -> None:
+                self.metadata: dict[str, object] = {}
+
             async def create_payment(self, **_: object) -> dict[str, object]:
+                self.metadata = dict(_.get("metadata", {}))
                 return {
                     "id": "pay_1",
                     "status": "pending",
@@ -88,9 +92,8 @@ class TestBillingServiceCore:
                     },
                 }
 
-        monkeypatch.setattr(
-            billing_utils, "get_yookassa_client", lambda: FakeYooKassaClient()
-        )
+        fake_client = FakeYooKassaClient()
+        monkeypatch.setattr(billing_utils, "get_yookassa_client", lambda: fake_client)
         # Receipt generation needs a real user/contact in the DB. This unit-style
         # test focuses on payment wiring + transaction updates.
         monkeypatch.setattr(billing_utils, "BILLING_RECEIPT_ENABLED", False)
@@ -120,3 +123,4 @@ class TestBillingServiceCore:
         assert updates
         assert updates[-1][1]["yookassa_payment_id"] == "pay_1"
         assert updates[-1][1]["yookassa_status"] == "pending"
+        assert "user_email" not in fake_client.metadata

--- a/backend/open_webui/utils/billing.py
+++ b/backend/open_webui/utils/billing.py
@@ -449,6 +449,11 @@ class BillingService:
 
         raise ValueError("Set billing contact email or phone in billing settings to issue a payment receipt")
 
+    async def _resolve_user_email(self, user_id: str) -> Optional[str]:
+        """Return the account email for provider-side payment identification."""
+        user = await Users.get_user_by_id(user_id)
+        return self._clean_contact(user.email) if user else None
+
     async def _build_receipt(
         self,
         user_id: str,
@@ -537,6 +542,14 @@ class BillingService:
             plan.currency,
             transaction.description or f"Subscription: {plan.name}",
         )
+        metadata: JsonDict = {
+            "user_id": user_id,
+            "plan_id": plan_id,
+            "transaction_id": created_transaction.id,
+        }
+        user_email = await self._resolve_user_email(user_id)
+        if user_email:
+            metadata["user_email"] = user_email
 
         # Create payment via YooKassa
         payment = await yookassa.create_payment(
@@ -544,11 +557,7 @@ class BillingService:
             currency=plan.currency,
             description=transaction.description,
             return_url=return_url,
-            metadata={
-                "user_id": user_id,
-                "plan_id": plan_id,
-                "transaction_id": created_transaction.id,
-            },
+            metadata=metadata,
             receipt=receipt,
         )
 
@@ -614,6 +623,9 @@ class BillingService:
             "wallet_id": wallet_id,
             "amount_kopeks": amount_kopeks,
         }
+        user_email = await self._resolve_user_email(user_id)
+        if user_email:
+            metadata["user_email"] = user_email
         topup_description = f"Top-up wallet {amount_rub} {BILLING_DEFAULT_CURRENCY}"
         receipt = await self._build_receipt(
             user_id,
@@ -746,6 +758,9 @@ class BillingService:
             "auto_topup": True,
             "auto_topup_reason": reason,
         }
+        user_email = await self._resolve_user_email(user_id)
+        if user_email:
+            metadata["user_email"] = user_email
         auto_topup_description = f"Auto top-up wallet {amount_rub} {BILLING_DEFAULT_CURRENCY}"
         receipt = await self._build_receipt(
             user_id,

--- a/meta/memory_bank/branch_updates/2026-08-06-codex-bugfix-yookassa-payment-email.md
+++ b/meta/memory_bank/branch_updates/2026-08-06-codex-bugfix-yookassa-payment-email.md
@@ -1,0 +1,10 @@
+### Done
+
+- [x] **[BUG][BILLING]** Include user email in YooKassa payment metadata
+  - Spec: `meta/memory_bank/specs/work_items/2026-08-06__bugfix__yookassa-payment-email.md`
+  - Owner: Codex
+  - Branch: `codex/bugfix/yookassa-payment-email`
+  - Done: 2026-08-06
+  - Summary: Added the account email to subscription, top-up, and auto-top-up YooKassa metadata for payer identification.
+  - Tests: `python -m py_compile ...`; `git diff --check`; pytest blocked by local test environment configuration.
+  - Risks: Email becomes visible in YooKassa payment metadata.

--- a/meta/memory_bank/specs/work_items/2026-08-06__bugfix__yookassa-payment-email.md
+++ b/meta/memory_bank/specs/work_items/2026-08-06__bugfix__yookassa-payment-email.md
@@ -1,0 +1,56 @@
+# YooKassa payment email identifier
+
+## Meta
+
+- Type: bugfix
+- Status: done
+- Owner: Codex
+- Branch: codex/bugfix/yookassa-payment-email
+- SDD Spec (JSON, required for non-trivial): N/A
+- Created: 2026-08-06
+- Updated: 2026-08-06
+
+## Context
+
+YooKassa payment metadata currently contains internal identifiers but not the account email, making it difficult to identify the payer in the YooKassa dashboard.
+
+## Goal / Acceptance Criteria
+
+- [x] Include the user's account email in metadata for subscription, manual top-up, and auto-top-up payments.
+- [x] Preserve existing payment processing and receipt behavior.
+- [x] Add regression coverage for top-up metadata.
+
+## Non-goals
+
+- No database migration or new dependency.
+- No changes to webhook ownership resolution.
+
+## Scope (what changes)
+
+- Backend: add `user_email` to YooKassa metadata when the account email is available.
+- Frontend: none.
+
+## Implementation Notes
+
+- Reuse the existing `Users` model and clean the email before sending it.
+- Store the same metadata in local payment records for top-ups.
+
+## Upstream impact
+
+- Upstream-owned files touched: `backend/open_webui/utils/billing.py`.
+- Why unavoidable: this is the shared payment creation path.
+- Minimization strategy: one helper and metadata additions only.
+
+## Verification
+
+- Targeted backend pytest for billing service/top-up tests.
+
+## Risks / Rollback
+
+- Risk: account email is personal data exposed to the merchant payment dashboard; this is explicitly requested and is sent only in payment metadata.
+- Rollback: remove `user_email` metadata additions and helper.
+
+## Completion Checklist
+
+- [x] Python compilation and `git diff --check` pass.
+- [x] Branch update moved to Done.


### PR DESCRIPTION
## What changed
- Add cleaned account email to YooKassa metadata for subscription, top-up, and auto-top-up payments.
- Keep local top-up metadata aligned with provider metadata.
- Add regression assertions and Memory Bank work-item tracking.

## Root cause
The email was only included in fiscal receipt data, so it was absent from payment metadata when receipts were disabled or when identifying payments directly in YooKassa.

## Validation
- `python -m py_compile ...`
- `git diff --check`
- Docker billing confidence attempted; blocked by a compose image pull/network hang.

## Risk
The account email is intentionally visible in YooKassa payment metadata.