### PR TITLE
test: restore billing coverage gate

### DIFF
--- a/backend/open_webui/test/apps/webui/utils/test_billing_service_extended.py
+++ b/backend/open_webui/test/apps/webui/utils/test_billing_service_extended.py
@@ -143,6 +143,25 @@ class TestBillingServiceExtended:
         assert delayed_result is not None
         assert updates[-1] == {'cancel_at_period_end': True}
 
+    def test_resume_subscription_clears_scheduled_cancellation(
+        self, monkeypatch: MonkeyPatch
+    ) -> None:
+        service = BillingService()
+        updates: list[dict[str, object]] = []
+
+        def _update_subscription(_sub_id: str, payload: dict[str, object]) -> object:
+            updates.append(payload)
+            return SimpleNamespace(id='sub_1', **payload)
+
+        monkeypatch.setattr(
+            service.subscriptions, 'update_subscription', _update_subscription
+        )
+
+        resumed = service.resume_subscription('sub_1')
+
+        assert resumed is not None
+        assert updates == [{'cancel_at_period_end': False}]
+
     def test_get_current_period_usage_without_subscription_uses_fallback_window(
         self, monkeypatch: MonkeyPatch
     ) -> None:

--- a/meta/memory_bank/branch_updates/2026-08-06-codex-bugfix-billing-coverage-gate.md
+++ b/meta/memory_bank/branch_updates/2026-08-06-codex-bugfix-billing-coverage-gate.md
@@ -4,5 +4,5 @@
   - Branch: `codex/bugfix/billing-coverage-gate`
   - Started: 2026-08-06
   - Summary: Add one direct test for the uncovered subscription resume path; do not change runtime code or coverage thresholds.
-  - Tests: Billing service extended suite 10 passed; Ruff and diff check passed. Coverage gate pending CI.
+  - Tests: Billing service suite 10 passed; exact coverage suite 196 passed; utils line/branch 85.26%/75.55%; unchanged gate passed; Ruff and diff check passed.
   - Risks: None to runtime behavior; production remains blocked until release-heavy is green.

--- a/meta/memory_bank/branch_updates/2026-08-06-codex-bugfix-billing-coverage-gate.md
+++ b/meta/memory_bank/branch_updates/2026-08-06-codex-bugfix-billing-coverage-gate.md
@@ -1,0 +1,8 @@
+- [ ] **[BUG][BILLING][COVERAGE]** Restore the unchanged billing coverage release gate
+  - Spec: `meta/memory_bank/specs/work_items/2026-08-06__bugfix__billing-coverage-gate.md`
+  - Owner: Codex
+  - Branch: `codex/bugfix/billing-coverage-gate`
+  - Started: 2026-08-06
+  - Summary: Add one direct test for the uncovered subscription resume path; do not change runtime code or coverage thresholds.
+  - Tests: Billing service extended suite 10 passed; Ruff and diff check passed. Coverage gate pending CI.
+  - Risks: None to runtime behavior; production remains blocked until release-heavy is green.

--- a/meta/memory_bank/specs/work_items/2026-08-06__bugfix__billing-coverage-gate.md
+++ b/meta/memory_bank/specs/work_items/2026-08-06__bugfix__billing-coverage-gate.md
@@ -17,7 +17,7 @@ The post-merge `merge-medium` billing run passed 195 backend tests, frontend tes
 ## Goal / Acceptance Criteria
 
 - [x] Cover an existing untested billing service path without changing runtime behavior or lowering thresholds.
-- [ ] Billing coverage for `open_webui/utils/billing.py` is at least 85%.
+- [x] Billing coverage for `open_webui/utils/billing.py` is at least 85%.
 - [ ] Follow-up PR is merged before `release-heavy` and production rollout.
 
 ## Scope
@@ -33,7 +33,7 @@ The post-merge `merge-medium` billing run passed 195 backend tests, frontend tes
 ## Verification
 
 - Billing service extended suite: 10 passed in the exact production candidate image.
-- Billing coverage suite and unchanged module coverage gate.
+- Exact billing coverage suite: 196 passed; utils line 85.26%, branch 75.55%; unchanged gate passed.
 - PR checks and post-merge billing confidence.
 
 ## Risks / Rollback

--- a/meta/memory_bank/specs/work_items/2026-08-06__bugfix__billing-coverage-gate.md
+++ b/meta/memory_bank/specs/work_items/2026-08-06__bugfix__billing-coverage-gate.md
@@ -1,0 +1,41 @@
+# Billing coverage gate follow-up
+
+## Meta
+
+- Type: bugfix
+- Status: active
+- Owner: Codex
+- Branch: `codex/bugfix/billing-coverage-gate`
+- Parent: `meta/memory_bank/specs/work_items/2026-08-06__bugfix__billing-release-gates-production.md`
+- Created: 2026-08-06
+- Updated: 2026-08-06
+
+## Context
+
+The post-merge `merge-medium` billing run passed 195 backend tests, frontend tests, and nine wallet E2E tests, but stopped because `open_webui/utils/billing.py` line coverage was 84.72% against the unchanged 85% release threshold.
+
+## Goal / Acceptance Criteria
+
+- [x] Cover an existing untested billing service path without changing runtime behavior or lowering thresholds.
+- [ ] Billing coverage for `open_webui/utils/billing.py` is at least 85%.
+- [ ] Follow-up PR is merged before `release-heavy` and production rollout.
+
+## Scope
+
+- Add one direct regression test for resuming a scheduled subscription cancellation.
+- No production code, dependency, schema, configuration, or threshold changes.
+
+## Upstream impact
+
+- Upstream-owned runtime files touched: none.
+- Test-only addition to the fork billing suite.
+
+## Verification
+
+- Billing service extended suite: 10 passed in the exact production candidate image.
+- Billing coverage suite and unchanged module coverage gate.
+- PR checks and post-merge billing confidence.
+
+## Risks / Rollback
+
+- Risk is limited to test behavior; rollback is reverting the test commit.


### PR DESCRIPTION
## Summary
- cover the existing subscription resume service path
- keep runtime behavior and all coverage thresholds unchanged
- unblock the billing merge-medium/release-heavy gates (84.72% was below the 85% utils line threshold)

## Verification
- billing service extended suite: 10 passed
- focused resume test: passed
- Ruff and git diff check: passed

## Risk
Test and documentation only; no production code, dependency, schema, configuration, or threshold changes.

Parent rollout: #90