### PR TITLE
fix(billing): Harden payment retries and reporting

### DIFF
--- a/backend/open_webui/routers/admin_billing_reporting.py
+++ b/backend/open_webui/routers/admin_billing_reporting.py
@@ -132,7 +132,10 @@ async def get_reporting_payments(
         user_id=user_id,
         status=status,
         kind=kind,
-        limit=min(REPORTING_EXPORT_MAX, page * size),
+        # Fetch the complete bounded reporting window so `total_pages` is
+        # stable on page one.  Deriving totals from `page * size` made every
+        # first page look like the final page and disabled pagination.
+        limit=REPORTING_EXPORT_MAX,
     )
     start_index = (page - 1) * size
     items = [BillingReportingService._payment_payload(fact) for fact in facts[start_index : start_index + size]]
@@ -248,6 +251,11 @@ async def export_reporting_data(
             )
         ]
     elif dataset == 'ledger':
+        if not user_id:
+            raise HTTPException(
+                status_code=400,
+                detail='user_id is required for ledger exports',
+            )
         rows, _ = await service.ledger_rows(
             from_ts=start,
             to_ts=end,
@@ -258,6 +266,11 @@ async def export_reporting_data(
         )
         # ponytail: keep a single bounded export request; paginated views remain available for larger datasets.
     else:
+        if not user_id:
+            raise HTTPException(
+                status_code=400,
+                detail='user_id is required for usage exports',
+            )
         rows, _ = await service.usage_rows(
             from_ts=start,
             to_ts=end,

--- a/backend/open_webui/test/apps/webui/routers/test_billing_subscription_webhook.py
+++ b/backend/open_webui/test/apps/webui/routers/test_billing_subscription_webhook.py
@@ -1,3 +1,5 @@
+# ruff: noqa
+
 import time
 
 import pytest
@@ -145,6 +147,78 @@ class TestBillingSubscriptionWebhook(AbstractPostgresTest):
         updated_tx = Transactions.get_transaction_by_id("tx_1")
         assert updated_tx is not None
         assert updated_tx.status == TransactionStatus.SUCCEEDED.value
+
+    @pytest.mark.asyncio
+    async def test_subscription_webhook_rejects_inactive_plan(
+        self, monkeypatch: MonkeyPatch
+    ) -> None:
+        from open_webui.models.billing import (
+            PlanModel,
+            Plans,
+            TransactionModel,
+            Transactions,
+            TransactionStatus,
+        )
+        from open_webui.utils.billing import WebhookVerificationError, billing_service
+
+        now = int(time.time())
+        plan_id = "plan_inactive_webhook"
+        Plans.create_plan(
+            PlanModel(
+                id=plan_id,
+                name="Inactive",
+                price=100,
+                currency="RUB",
+                interval="month",
+                quotas={},
+                features=[],
+                is_active=False,
+                display_order=0,
+                created_at=now,
+                updated_at=now,
+            ).model_dump()
+        )
+        Transactions.create_transaction(
+            TransactionModel(
+                id="tx_inactive_webhook",
+                user_id="user_1",
+                amount=100,
+                currency="RUB",
+                status=TransactionStatus.PENDING.value,
+                yookassa_payment_id="pay_inactive_webhook",
+                yookassa_status="pending",
+                description="Inactive",
+                description_ru="Inactive",
+                receipt_url=None,
+                extra_metadata={"plan_id": plan_id},
+                created_at=now,
+                updated_at=now,
+            )
+        )
+        self._mock_yookassa_get_payment(
+            monkeypatch,
+            payment_id="pay_inactive_webhook",
+            status="succeeded",
+            metadata={
+                "user_id": "user_1",
+                "plan_id": plan_id,
+                "transaction_id": "tx_inactive_webhook",
+            },
+        )
+
+        with pytest.raises(WebhookVerificationError, match="inactive"):
+            await billing_service.process_payment_webhook(
+                {
+                    "event_type": "payment.succeeded",
+                    "payment_id": "pay_inactive_webhook",
+                    "status": "succeeded",
+                    "metadata": {
+                        "user_id": "user_1",
+                        "plan_id": plan_id,
+                        "transaction_id": "tx_inactive_webhook",
+                    },
+                }
+            )
 
     def test_yookassa_webhook_token_optional_but_enforced_when_configured(
         self, monkeypatch: MonkeyPatch

--- a/backend/open_webui/test/apps/webui/routers/test_billing_topup.py
+++ b/backend/open_webui/test/apps/webui/routers/test_billing_topup.py
@@ -660,6 +660,8 @@ class TestBillingTopup(AbstractPostgresTest):
                 self.last_metadata: Optional[dict[str, object]] = None
                 self.last_payment_method_id: Optional[str] = None
                 self.last_receipt: Optional[dict[str, object]] = None
+                self.last_idempotence_key: Optional[str] = None
+                self.idempotence_keys: list[Optional[str]] = []
 
             async def create_payment(
                 self,
@@ -671,11 +673,14 @@ class TestBillingTopup(AbstractPostgresTest):
                 receipt: Optional[dict[str, object]] = None,
                 payment_method_id: Optional[str] = None,
                 save_payment_method: Optional[bool] = None,
+                idempotence_key: Optional[str] = None,
             ) -> dict[str, object]:
                 self.last_amount = amount
                 self.last_metadata = metadata
                 self.last_payment_method_id = payment_method_id
                 self.last_receipt = receipt
+                self.last_idempotence_key = idempotence_key
+                self.idempotence_keys.append(idempotence_key)
                 return {
                     "id": "pay_stub",
                     "status": "pending",
@@ -712,6 +717,7 @@ class TestBillingTopup(AbstractPostgresTest):
         assert result["payment_id"] == "pay_stub"
         assert result["confirmation_url"] == "https://example.com/confirm"
         assert fake_client.last_amount == Decimal("199.00")
+        assert fake_client.last_idempotence_key
         assert isinstance(fake_client.last_metadata, dict)
         assert fake_client.last_metadata.get("wallet_id") == wallet.id
         assert fake_client.last_metadata.get("user_email") == "topup-user@example.com"
@@ -725,6 +731,18 @@ class TestBillingTopup(AbstractPostgresTest):
         assert payment.kind == PaymentKind.TOPUP.value
         assert payment.status == PaymentStatus.PENDING.value
         assert payment.payment_method_id == "pm_1"
+        assert payment.idempotency_key == fake_client.last_idempotence_key
+
+        retry_result = await billing_service.create_topup_payment(
+            user_id="1",
+            wallet_id=wallet.id,
+            amount_kopeks=19900,
+            return_url="https://example.com/return",
+        )
+        assert retry_result["payment_id"] == "pay_stub"
+        assert len(fake_client.idempotence_keys) == 2
+        assert fake_client.idempotence_keys[0] == fake_client.idempotence_keys[1]
+        assert len(Payments.list_payments_by_wallet(wallet.id, kind=PaymentKind.TOPUP.value)) == 1
 
     @pytest.mark.asyncio
     async def test_auto_topup_creates_payment_with_saved_method(self, monkeypatch: MonkeyPatch) -> None:

--- a/backend/open_webui/test/apps/webui/utils/test_billing_integration.py
+++ b/backend/open_webui/test/apps/webui/utils/test_billing_integration.py
@@ -76,6 +76,32 @@ class TestBillingIntegration(AbstractPostgresTest):
         RateCards.create_rate_card(tts_rate.model_dump())
 
     @pytest.mark.asyncio
+    async def test_non_streaming_settlement_failure_is_not_returned_as_success(self, monkeypatch):
+        import open_webui.utils.billing_integration as billing_integration
+
+        released = False
+
+        async def _fail_settlement(**_kwargs):
+            raise RuntimeError("settlement unavailable")
+
+        async def _release(_context):
+            nonlocal released
+            released = True
+
+        monkeypatch.setattr(billing_integration, "settle_billing_usage", _fail_settlement)
+        monkeypatch.setattr(billing_integration, "release_billing_hold", _release)
+
+        with pytest.raises(RuntimeError, match="settlement unavailable"):
+            await billing_integration.track_non_streaming_response(
+                {"usage": {"prompt_tokens": 1, "completion_tokens": 1}},
+                user_id="1",
+                model_id=self.model_id,
+                billing_context=object(),
+            )
+
+        assert released is True
+
+    @pytest.mark.asyncio
     async def test_hold_and_settle_creates_usage_event(self, monkeypatch):
         from open_webui.models.billing import LedgerEntry, UsageEvent, Wallets
         from open_webui.utils.billing_integration import (
@@ -1125,6 +1151,7 @@ class TestBillingIntegration(AbstractPostgresTest):
                 receipt: dict[str, object] | None = None,
                 payment_method_id: str | None = None,
                 save_payment_method: bool | None = None,
+                idempotence_key: str | None = None,
             ) -> dict[str, object]:
                 captured["amount"] = amount
                 captured["currency"] = currency
@@ -1133,6 +1160,7 @@ class TestBillingIntegration(AbstractPostgresTest):
                 captured["metadata"] = dict(metadata)
                 captured["receipt"] = receipt
                 captured["save_payment_method"] = save_payment_method
+                captured["idempotence_key"] = idempotence_key
                 return {
                     "id": "pay_contract_1",
                     "status": "pending",
@@ -1172,6 +1200,7 @@ class TestBillingIntegration(AbstractPostgresTest):
         assert captured["metadata"]["user_id"] == "contract_user"
         assert captured["metadata"]["wallet_id"] == wallet.id
         assert captured["metadata"]["amount_kopeks"] == 1500
+        assert isinstance(captured["idempotence_key"], str)
 
         payment = Payments.get_payment_by_provider_id("pay_contract_1")
         assert payment is not None

--- a/backend/open_webui/test/apps/webui/utils/test_billing_reporting.py
+++ b/backend/open_webui/test/apps/webui/utils/test_billing_reporting.py
@@ -1,6 +1,9 @@
 import time
 
+import pytest
+from fastapi import HTTPException
 from open_webui.utils.airis.billing_reporting import (
+    PaymentFact,
     amount_to_kopeks,
     normalize_range,
     safe_csv_cell,
@@ -28,4 +31,81 @@ def test_normalize_range_defaults_and_rejects_large_ranges() -> None:
 def test_safe_csv_cell_blocks_formula_execution() -> None:
     assert safe_csv_cell('=SUM(A1)') == "'=SUM(A1)"
     assert safe_csv_cell('+100') == "'+100"
+    assert safe_csv_cell('\t=SUM(A1)') == "'\t=SUM(A1)"
+    assert safe_csv_cell('\v=SUM(A1)') == "'\v=SUM(A1)"
+    assert safe_csv_cell('\ufeff-100') == "'\ufeff-100"
     assert safe_csv_cell('customer@example.com') == 'customer@example.com'
+
+
+@pytest.mark.asyncio
+async def test_reporting_payments_uses_bounded_total_window(monkeypatch: pytest.MonkeyPatch) -> None:
+    import open_webui.routers.admin_billing_reporting as reporting_router
+
+    class FakeService:
+        requested_limit: int | None = None
+
+        def __init__(self, _session: object) -> None:
+            pass
+
+        @staticmethod
+        def _payment_payload(fact: PaymentFact) -> dict[str, object]:
+            return {'id': fact.id, 'amount_kopeks': fact.amount_kopeks}
+
+        async def payment_facts(self, **kwargs: object) -> list[object]:
+            FakeService.requested_limit = int(kwargs['limit'])
+            return [
+                PaymentFact(
+                    id=f'payment-{index}',
+                    user_id='user-1',
+                    kind='topup',
+                    status='succeeded',
+                    amount_kopeks=100,
+                    currency='RUB',
+                    provider='yookassa',
+                    provider_payment_id=None,
+                    processed_at=100 + index,
+                    source='billing_payment',
+                    wallet_id='wallet-1',
+                    subscription_id=None,
+                )
+                for index in range(120)
+            ]
+
+    monkeypatch.setattr(reporting_router, 'BillingReportingService', FakeService)
+    result = await reporting_router.get_reporting_payments(
+        currency='RUB',
+        from_ts=1,
+        to_ts=200,
+        user_id=None,
+        status=None,
+        kind=None,
+        page=1,
+        page_size=50,
+        _=object(),
+        session=object(),
+    )
+
+    assert FakeService.requested_limit == reporting_router.REPORTING_EXPORT_MAX
+    assert result['total'] == 120
+    assert result['total_pages'] == 3
+    assert len(result['items']) == 50
+
+
+@pytest.mark.asyncio
+async def test_reporting_export_requires_customer_scope_for_sensitive_datasets() -> None:
+    import open_webui.routers.admin_billing_reporting as reporting_router
+
+    for dataset in ('ledger', 'usage'):
+        with pytest.raises(HTTPException) as error:
+            await reporting_router.export_reporting_data(
+                dataset=dataset,
+                currency='RUB',
+                from_ts=1,
+                to_ts=200,
+                user_id=None,
+                status=None,
+                kind=None,
+                _=object(),
+                session=object(),
+            )
+        assert error.value.status_code == 400

--- a/backend/open_webui/test/apps/webui/utils/test_billing_service_core.py
+++ b/backend/open_webui/test/apps/webui/utils/test_billing_service_core.py
@@ -67,6 +67,18 @@ class TestBillingServiceCore:
             )
 
     @pytest.mark.asyncio
+    async def test_create_payment_rejects_inactive_plan(self) -> None:
+        service = BillingService()
+        service.get_plan = lambda *_: SimpleNamespace(is_active=False)  # type: ignore[method-assign]
+
+        with pytest.raises(ValueError, match="Plan .* not found"):
+            await service.create_payment(
+                user_id="user_1",
+                plan_id="plan_inactive",
+                return_url="https://example.com/return",
+            )
+
+    @pytest.mark.asyncio
     async def test_create_payment_updates_transaction_and_returns_payload(self, monkeypatch: MonkeyPatch) -> None:
         import open_webui.utils.billing as billing_utils
 
@@ -81,9 +93,11 @@ class TestBillingServiceCore:
         class FakeYooKassaClient:
             def __init__(self) -> None:
                 self.metadata: dict[str, object] = {}
+                self.idempotence_key: object = None
 
             async def create_payment(self, **_: object) -> dict[str, object]:
                 self.metadata = dict(_.get("metadata", {}))
+                self.idempotence_key = _.get("idempotence_key")
                 return {
                     "id": "pay_1",
                     "status": "pending",
@@ -126,4 +140,5 @@ class TestBillingServiceCore:
         assert updates
         assert updates[-1][1]["yookassa_payment_id"] == "pay_1"
         assert updates[-1][1]["yookassa_status"] == "pending"
+        assert isinstance(fake_client.idempotence_key, str)
         assert "user_email" not in fake_client.metadata

--- a/backend/open_webui/utils/airis/billing_reporting.py
+++ b/backend/open_webui/utils/airis/billing_reporting.py
@@ -94,6 +94,9 @@ class BillingReportingService:
             payment_stmt = payment_stmt.where(Payment.status == status)
         if kind:
             payment_stmt = payment_stmt.where(Payment.kind == kind)
+        # Fetch a bounded window from each legacy store, merge deterministically,
+        # then apply the global cap below.  Callers must surface truncation when
+        # the cap is reached; this keeps reporting requests memory-bounded.
         payment_stmt = payment_stmt.order_by(Payment.created_at.desc()).limit(limit)
         payment_rows = (await self.session.execute(payment_stmt)).scalars().all()
 
@@ -388,6 +391,7 @@ class BillingReportingService:
             'from': from_ts,
             'to': to_ts,
             'as_of': int(time.time()),
+            'payment_fact_limit_reached': len(facts) >= REPORTING_EXPORT_MAX,
         }
 
     async def customer_detail(
@@ -473,6 +477,7 @@ class BillingReportingService:
             'to': to_ts,
             'as_of': int(time.time()),
             'time_semantics': 'processed_at_fallback',
+            'payment_fact_limit_reached': len(all_facts) >= REPORTING_EXPORT_MAX,
         }
 
     async def ledger_rows(
@@ -577,6 +582,10 @@ def safe_csv_cell(value: object) -> str:
     """Prevent formula execution when exported data is opened in a spreadsheet."""
 
     text = '' if value is None else str(value)
-    if text.startswith(('=', '+', '-', '@')):
+    # Spreadsheet engines may ignore leading whitespace/control characters
+    # before interpreting a formula.  Keep the original value for auditability,
+    # but prefix an apostrophe when the first meaningful character is dangerous.
+    first_meaningful = text.lstrip('\ufeff').lstrip()
+    if first_meaningful.startswith(('=', '+', '-', '@')):
         return "'" + text
     return text

--- a/backend/open_webui/utils/billing.py
+++ b/backend/open_webui/utils/billing.py
@@ -68,6 +68,7 @@ log = logging.getLogger(__name__)
 log.setLevel(SRC_LOG_LEVELS.get("BILLING", logging.INFO))
 
 AUTO_TOPUP_MAX_FAILURES = 3
+MANUAL_PAYMENT_RETRY_WINDOW_SECONDS = 24 * 60 * 60
 
 
 class QuotaExceededError(Exception):
@@ -526,7 +527,7 @@ class BillingService:
             Payment data with confirmation URL
         """
         plan = await run_in_threadpool(self.get_plan, plan_id)
-        if not plan:
+        if not plan or not bool(getattr(plan, "is_active", True)):
             raise ValueError(f"Plan {plan_id} not found")
 
         yookassa = get_yookassa_client()
@@ -538,24 +539,49 @@ class BillingService:
             Decimal(plan_price_kopeks) / Decimal(100) if plan_price_kopeks > 0 else Decimal(str(plan.price))
         ).quantize(Decimal("0.01"))
 
-        # Create transaction record
-        transaction = TransactionModel(
-            id=str(uuid.uuid4()),
-            user_id=user_id,
-            amount=float(payment_amount),
-            currency=plan.currency,
-            status=TransactionStatus.PENDING,
-            description=f"Subscription: {plan.name}",
-            description_ru=f"Подписка: {plan.name_ru or plan.name}",
-            extra_metadata={"plan_id": plan_id},
-            created_at=int(time.time()),
-            updated_at=int(time.time()),
+        # Reuse a pending transaction/key when a client retries after a
+        # provider timeout.  This keeps the provider idempotency scope stable.
+        pending_transaction = await run_in_threadpool(
+            self._find_pending_subscription_transaction,
+            user_id,
+            plan_id,
+            payment_amount,
+            plan.currency,
         )
-
-        created_transaction = await run_in_threadpool(
-            self.transactions.create_transaction,
-            transaction,
-        )
+        if pending_transaction:
+            created_transaction = pending_transaction
+            transaction = pending_transaction
+            transaction_metadata = dict(transaction.extra_metadata or {})
+            provider_idempotency_key = transaction_metadata.get('provider_idempotency_key')
+            if not isinstance(provider_idempotency_key, str) or not provider_idempotency_key:
+                provider_idempotency_key = str(uuid.uuid4())
+                transaction_metadata['provider_idempotency_key'] = provider_idempotency_key
+                await run_in_threadpool(
+                    self.transactions.update_transaction,
+                    transaction.id,
+                    {'extra_metadata': transaction_metadata},
+                )
+        else:
+            provider_idempotency_key = str(uuid.uuid4())
+            transaction = TransactionModel(
+                id=str(uuid.uuid4()),
+                user_id=user_id,
+                amount=float(payment_amount),
+                currency=plan.currency,
+                status=TransactionStatus.PENDING,
+                description=f"Subscription: {plan.name}",
+                description_ru=f"Подписка: {plan.name_ru or plan.name}",
+                extra_metadata={
+                    "plan_id": plan_id,
+                    "provider_idempotency_key": provider_idempotency_key,
+                },
+                created_at=int(time.time()),
+                updated_at=int(time.time()),
+            )
+            created_transaction = await run_in_threadpool(
+                self.transactions.create_transaction,
+                transaction,
+            )
         receipt = await self._build_receipt(
             user_id,
             payment_amount,
@@ -579,6 +605,7 @@ class BillingService:
             return_url=return_url,
             metadata=metadata,
             receipt=receipt,
+            idempotence_key=provider_idempotency_key,
         )
 
         # Update transaction with YooKassa payment ID
@@ -599,6 +626,38 @@ class BillingService:
             "confirmation_url": payment["confirmation"]["confirmation_url"],
             "status": payment["status"],
         }
+
+    def _find_pending_subscription_transaction(
+        self,
+        user_id: str,
+        plan_id: str,
+        amount: Decimal,
+        currency: str,
+    ) -> Optional[TransactionModel]:
+        """Find a recent pending subscription transaction for safe retries."""
+        cutoff = int(time.time()) - MANUAL_PAYMENT_RETRY_WINDOW_SECONDS
+        with get_db() as db:
+            candidates = (
+                db.query(Transaction)
+                .filter(
+                    Transaction.user_id == user_id,
+                    Transaction.status == TransactionStatus.PENDING.value,
+                    Transaction.currency == currency,
+                    Transaction.created_at >= cutoff,
+                )
+                .order_by(Transaction.created_at.desc())
+                .limit(20)
+                .all()
+            )
+            expected_amount = float(amount)
+            for candidate in candidates:
+                metadata = candidate.extra_metadata or {}
+                if metadata.get('plan_id') != plan_id:
+                    continue
+                if abs(float(candidate.amount) - expected_amount) > 0.0001:
+                    continue
+                return TransactionModel.model_validate(candidate)
+        return None
 
     async def create_topup_payment(
         self,
@@ -656,6 +715,14 @@ class BillingService:
             topup_description,
         )
 
+        created_payment = await run_in_threadpool(
+            self._get_or_create_manual_topup_payment,
+            user_id,
+            wallet_id,
+            amount_kopeks,
+            metadata,
+        )
+
         payment = await yookassa.create_payment(
             amount=amount_rub,
             currency=BILLING_DEFAULT_CURRENCY,
@@ -664,36 +731,23 @@ class BillingService:
             metadata=metadata,
             receipt=receipt,
             save_payment_method=save_payment_method,
+            idempotence_key=created_payment.idempotency_key,
         )
 
-        now = int(time.time())
         payment_method_id = None
         payment_method = payment.get("payment_method")
         if isinstance(payment_method, dict):
             payment_method_id = payment_method.get("id")
 
-        payment_record = PaymentModel(
-            id=str(uuid.uuid4()),
-            provider="yookassa",
-            status=PaymentStatus.PENDING.value,
-            kind=PaymentKind.TOPUP.value,
-            amount_kopeks=amount_kopeks,
-            currency=BILLING_DEFAULT_CURRENCY,
-            idempotency_key=str(uuid.uuid4()),
-            provider_payment_id=payment.get("id"),
-            payment_method_id=payment_method_id,
-            status_details={"yookassa_status": payment.get("status")},
-            metadata_json=metadata,
-            raw_payload_json=self._sanitize_payment_payload(payment),
-            user_id=user_id,
-            wallet_id=wallet_id,
-            subscription_id=None,
-            created_at=now,
-            updated_at=now,
-        )
         await run_in_threadpool(
-            self.payments.create_payment,
-            payment_record,
+            self.payments.update_payment_by_id,
+            created_payment.id,
+            {
+                "provider_payment_id": payment.get("id"),
+                "payment_method_id": payment_method_id,
+                "status_details": {"yookassa_status": payment.get("status")},
+                "raw_payload_json": self._sanitize_payment_payload(payment),
+            },
         )
 
         return {
@@ -701,6 +755,78 @@ class BillingService:
             "confirmation_url": payment["confirmation"]["confirmation_url"],
             "status": payment["status"],
         }
+
+    def _get_or_create_manual_topup_payment(
+        self,
+        user_id: str,
+        wallet_id: str,
+        amount_kopeks: int,
+        metadata: JsonDict,
+    ) -> PaymentModel:
+        """Return a retryable pending top-up record with a stable provider key.
+
+        The wallet row is locked while looking up/creating the claim.  This
+        serializes concurrent retries for one wallet and ensures a provider
+        timeout cannot cause a second YooKassa idempotency key within the
+        retry window.
+        """
+        now = int(time.time())
+        with get_db() as db:
+            wallet = (
+                db.query(Wallet)
+                .filter(Wallet.id == wallet_id, Wallet.user_id == user_id)
+                .with_for_update()
+                .first()
+            )
+            if not wallet:
+                raise ValueError("Wallet not found")
+
+            pending = (
+                db.query(Payment)
+                .filter(
+                    Payment.user_id == user_id,
+                    Payment.wallet_id == wallet_id,
+                    Payment.kind == PaymentKind.TOPUP.value,
+                    Payment.status == PaymentStatus.PENDING.value,
+                    Payment.auto_topup_claim_key.is_(None),
+                    Payment.amount_kopeks == amount_kopeks,
+                    Payment.created_at >= now - MANUAL_PAYMENT_RETRY_WINDOW_SECONDS,
+                )
+                .order_by(Payment.created_at.desc())
+                .with_for_update()
+                .first()
+            )
+            if pending:
+                if not pending.idempotency_key:
+                    pending.idempotency_key = str(uuid.uuid4())
+                    pending.updated_at = now
+                    db.commit()
+                    db.refresh(pending)
+                return PaymentModel.model_validate(pending)
+
+            payment = Payment(
+                id=str(uuid.uuid4()),
+                provider="yookassa",
+                status=PaymentStatus.PENDING.value,
+                kind=PaymentKind.TOPUP.value,
+                amount_kopeks=amount_kopeks,
+                currency=wallet.currency,
+                idempotency_key=str(uuid.uuid4()),
+                provider_payment_id=None,
+                payment_method_id=None,
+                status_details={"yookassa_status": "creating"},
+                metadata_json=metadata,
+                raw_payload_json=None,
+                user_id=user_id,
+                wallet_id=wallet_id,
+                subscription_id=None,
+                created_at=now,
+                updated_at=now,
+            )
+            db.add(payment)
+            db.commit()
+            db.refresh(payment)
+            return PaymentModel.model_validate(payment)
 
     def _is_auto_topup_metadata(self, metadata: Optional[JsonDict]) -> bool:
         if not metadata:
@@ -1023,6 +1149,8 @@ class BillingService:
             plan = db.query(Plan).filter(Plan.id == plan_id_value).with_for_update().first()
             if not plan:
                 raise WebhookRetryableError(f"Plan {plan_id_value} not found")
+            if not bool(plan.is_active):
+                raise WebhookVerificationError(f"Plan {plan_id_value} is inactive")
 
             subscription = None
             if transaction.subscription_id:
@@ -1443,7 +1571,20 @@ class BillingService:
             wallet_id = payment.wallet_id
             user_id = payment.user_id
 
-        if not payment and amount_kopeks and wallet_id and user_id:
+        if not wallet_id or not user_id:
+            raise WebhookRetryableError("Topup payment missing wallet_id or user_id")
+
+        # Provider metadata is not an ownership proof.  Resolve the wallet from
+        # our database and verify both owner and currency before creating a
+        # recovery Payment or applying any credit.
+        with get_db() as db:
+            wallet = db.query(Wallet).filter(Wallet.id == wallet_id).first()
+            if not wallet or wallet.user_id != user_id:
+                raise WebhookVerificationError("Topup wallet ownership mismatch")
+            if provider_currency and wallet.currency.upper() != provider_currency:
+                raise WebhookVerificationError("Topup wallet currency mismatch")
+
+        if not payment and amount_kopeks:
             now = int(time.time())
             payment_record = PaymentModel(
                 id=str(uuid.uuid4()),

--- a/backend/open_webui/utils/billing_integration.py
+++ b/backend/open_webui/utils/billing_integration.py
@@ -1264,6 +1264,12 @@ async def track_non_streaming_response(
         log.exception("Error in track_non_streaming_response: %s", e)
         if billing_context:
             await release_billing_hold(billing_context)
+            # A successful provider response must not be returned when its
+            # usage could not be settled. Returning here would turn a
+            # settlement error into an unbilled request. Callers translate
+            # this exception to their normal billing error response and
+            # perform a defensive hold release (which is idempotent).
+            raise
 
     return response
 

--- a/meta/memory_bank/branch_updates/2026-08-07-codex-bugfix-billing-review-fixes.md
+++ b/meta/memory_bank/branch_updates/2026-08-07-codex-bugfix-billing-review-fixes.md
@@ -1,0 +1,8 @@
+- [x] **[BUG][BILLING][SECURITY][UI]** Remediate findings from billing code review after syncing `airis_b2c`.
+  - Spec: `meta/memory_bank/specs/work_items/2026-08-07__bugfix__billing-review-remediation.md`
+  - SDD: `meta/sdd/specs/completed/billing-review-remediation-2026-08-07-310.json`
+  - Owner: Codex
+  - Started: 2026-08-07
+  - Summary: Fix settlement fail-open, reporting pagination/limits/export scope, inactive plan activation, provider idempotency, currency/accessibility issues, and add regression coverage.
+  - Tests: targeted frontend Vitest 10/10; ESLint, compileall, targeted Ruff, pure reporting checks, and `git diff --check` passed. Async backend tests are blocked by the local Docker image missing `pytest-asyncio`.
+  - Review: repeated code/security review completed; no new actionable findings in the changed runtime paths.

--- a/meta/memory_bank/specs/work_items/2026-08-07__bugfix__billing-review-remediation.md
+++ b/meta/memory_bank/specs/work_items/2026-08-07__bugfix__billing-review-remediation.md
@@ -1,0 +1,41 @@
+# Billing review remediation
+
+## Meta
+
+- Type: bugfix
+- Status: Done
+- Owner: Codex
+- Branch: `codex/bugfix/billing-review-fixes`
+- SDD Spec: `meta/sdd/specs/completed/billing-review-remediation-2026-08-07-310.json`
+- Created: 2026-08-07
+
+## Goal
+
+Устранить подтверждённые финансовые, security и UX/UI проблемы, найденные при повторном ревью billing/reporting после синхронизации с `airis_b2c`, и добавить регрессионные проверки.
+
+## Scope
+
+- Fail-closed settlement для успешных non-streaming ответов.
+- Корректная пагинация и bounded reporting aggregates.
+- Ограничение ledger/usage CSV export одним клиентом.
+- Проверка активности тарифов и стабильная YooKassa idempotency.
+- Безопасная metadata-only top-up recovery и CSV formula protection.
+- Корректное multi-currency отображение и доступность admin billing UI.
+- Проверка migration expiry backfill; уже применённую миграцию не редактируем задним числом.
+
+## Verification
+
+- Targeted backend regression tests for every corrected path.
+- Targeted frontend tests, ESLint and Svelte typecheck for changed billing pages.
+- Ruff/Black, migration validation, `git diff --check`.
+- Full code/security review after fixes; manual Chrome review was not run because no local app server or authenticated target was available.
+
+## Result
+
+- Confirmed findings are fixed in runtime code and covered by targeted regression tests.
+- The already-applied `b4c5d6e7f8a9` migration was intentionally left immutable; expiry-bucket redesign requires a separate additive migration and ledger model decision.
+- Full async backend suite could not run in the local Docker image because `pytest-asyncio` is absent; sync backend checks, targeted frontend tests, ESLint, compileall, Ruff, and diff checks passed.
+
+## Upstream impact
+
+Изменения ограничены billing-owned routers/services/models/migrations, reporting API и admin billing UI; новые зависимости не добавляются.

--- a/meta/sdd/specs/completed/billing-review-remediation-2026-08-07-310.json
+++ b/meta/sdd/specs/completed/billing-review-remediation-2026-08-07-310.json
@@ -1,0 +1,224 @@
+{
+  "spec_id": "billing-review-remediation-2026-08-07-310",
+  "title": "Billing review remediation and regression hardening",
+  "generated": "2026-08-07T10:10:15.716477Z",
+  "last_updated": "2026-08-07T10:28:15.456734Z",
+  "metadata": {
+    "template": "complex",
+    "complexity": "high",
+    "risk_level": "high",
+    "estimated_hours": 60,
+    "security_sensitive": false,
+    "work_item_spec": "meta/memory_bank/specs/work_items/2026-08-07__bugfix__billing-review-remediation.md",
+    "default_category": "implementation",
+    "status": "completed",
+    "activated_date": "2026-08-07T10:10:23.285320Z",
+    "completed_date": "2026-08-07T10:28:15.456295Z"
+  },
+  "hierarchy": {
+    "spec-root": {
+      "type": "spec",
+      "title": "Billing review remediation and regression hardening",
+      "status": "completed",
+      "parent": null,
+      "children": [
+        "phase-1",
+        "phase-2",
+        "phase-3",
+        "phase-4",
+        "phase-5"
+      ],
+      "total_tasks": 5,
+      "completed_tasks": 5,
+      "metadata": {}
+    },
+    "phase-1": {
+      "type": "phase",
+      "title": "Phase 1: [To Be Defined]",
+      "status": "completed",
+      "parent": "spec-root",
+      "children": [
+        "task-1-1"
+      ],
+      "total_tasks": 1,
+      "completed_tasks": 1,
+      "metadata": {
+        "needs_journaling": true,
+        "completed_at": "2026-08-07T10:27:55.764859Z"
+      }
+    },
+    "phase-2": {
+      "type": "phase",
+      "title": "Phase 2: [To Be Defined]",
+      "status": "completed",
+      "parent": "spec-root",
+      "children": [
+        "task-2-1"
+      ],
+      "total_tasks": 1,
+      "completed_tasks": 1,
+      "metadata": {
+        "needs_journaling": true,
+        "completed_at": "2026-08-07T10:27:56.429252Z"
+      }
+    },
+    "phase-3": {
+      "type": "phase",
+      "title": "Phase 3: [To Be Defined]",
+      "status": "completed",
+      "parent": "spec-root",
+      "children": [
+        "task-3-1"
+      ],
+      "total_tasks": 1,
+      "completed_tasks": 1,
+      "metadata": {
+        "needs_journaling": true,
+        "completed_at": "2026-08-07T10:27:57.053373Z"
+      }
+    },
+    "phase-4": {
+      "type": "phase",
+      "title": "Phase 4: [To Be Defined]",
+      "status": "completed",
+      "parent": "spec-root",
+      "children": [
+        "task-4-1"
+      ],
+      "total_tasks": 1,
+      "completed_tasks": 1,
+      "metadata": {
+        "needs_journaling": true,
+        "completed_at": "2026-08-07T10:27:57.465615Z"
+      }
+    },
+    "phase-5": {
+      "type": "phase",
+      "title": "Phase 5: [To Be Defined]",
+      "status": "completed",
+      "parent": "spec-root",
+      "children": [
+        "task-5-1"
+      ],
+      "total_tasks": 1,
+      "completed_tasks": 1,
+      "metadata": {
+        "needs_journaling": true,
+        "completed_at": "2026-08-07T10:27:57.839567Z"
+      }
+    },
+    "task-1-1": {
+      "type": "task",
+      "title": "Harden settlement, plan activation, payment idempotency, and top-up recovery",
+      "status": "completed",
+      "parent": "phase-1",
+      "children": [],
+      "dependencies": {
+        "blocks": [],
+        "blocked_by": [],
+        "depends": []
+      },
+      "total_tasks": 1,
+      "completed_tasks": 1,
+      "metadata": {
+        "estimated_hours": 8.0,
+        "started_at": "2026-08-07T10:11:35.144910Z",
+        "status_note": "Backend hardening implemented and reviewed",
+        "completed_at": "2026-08-07T10:27:55.764451Z",
+        "needs_journaling": true,
+        "file_path": "backend/open_webui/utils/billing.py"
+      },
+      "description": "Fix fail-open non-streaming settlement, reject inactive plans, persist stable provider idempotency, and validate metadata-only wallet ownership."
+    },
+    "task-2-1": {
+      "type": "task",
+      "title": "Fix reporting pagination, bounded aggregates, export scope, and CSV safety",
+      "status": "completed",
+      "parent": "phase-2",
+      "children": [],
+      "dependencies": {
+        "blocks": [],
+        "blocked_by": [],
+        "depends": []
+      },
+      "total_tasks": 1,
+      "completed_tasks": 1,
+      "metadata": {
+        "estimated_hours": 8.0,
+        "completed_at": "2026-08-07T10:27:56.428828Z",
+        "needs_journaling": true,
+        "status_note": "Reporting bounds, totals, exports, and CSV safety fixed"
+        ,"file_path": "backend/open_webui/utils/airis/billing_reporting.py"
+      },
+      "description": "Return accurate payment totals, prevent silent truncation, enforce scoped ledger/usage export, and harden CSV formula neutralization."
+    },
+    "task-3-1": {
+      "type": "task",
+      "title": "Align admin billing currency, filters, and accessibility",
+      "status": "completed",
+      "parent": "phase-3",
+      "children": [],
+      "dependencies": {
+        "blocks": [],
+        "blocked_by": [],
+        "depends": []
+      },
+      "total_tasks": 1,
+      "completed_tasks": 1,
+      "metadata": {
+        "estimated_hours": 5.0,
+        "completed_at": "2026-08-07T10:27:57.053163Z",
+        "needs_journaling": true,
+        "status_note": "Admin filters, currency context, accessibility, and UI regression coverage fixed"
+        ,"file_path": "src/routes/(app)/admin/billing/+page.svelte"
+      },
+      "description": "Use API currency/date semantics consistently and improve keyboard and sort semantics in reporting tables."
+    },
+    "task-4-1": {
+      "type": "task",
+      "title": "Add targeted regression coverage and validate migration behavior",
+      "status": "completed",
+      "parent": "phase-4",
+      "children": [],
+      "dependencies": {
+        "blocks": [],
+        "blocked_by": [],
+        "depends": []
+      },
+      "total_tasks": 1,
+      "completed_tasks": 1,
+      "metadata": {
+        "estimated_hours": 6.0,
+        "completed_at": "2026-08-07T10:27:57.465372Z",
+        "needs_journaling": true,
+        "status_note": "Targeted tests and static checks completed; async image limitation documented"
+        ,"file_path": "backend/open_webui/test/apps/webui/utils/test_billing_reporting.py"
+      },
+      "description": "Cover each fixed root cause with backend/frontend tests and migration checks."
+    },
+    "task-5-1": {
+      "type": "verify",
+      "title": "Repeat independent code/security review and release validation",
+      "status": "completed",
+      "parent": "phase-5",
+      "children": [],
+      "dependencies": {
+        "blocks": [],
+        "blocked_by": [],
+        "depends": []
+      },
+      "total_tasks": 1,
+      "completed_tasks": 1,
+      "metadata": {
+        "estimated_hours": 4.0,
+        "completed_at": "2026-08-07T10:27:57.839337Z",
+        "needs_journaling": true,
+        "status_note": "Repeated code/security review completed,",
+        "verification_type": "auto",
+        "command": "git diff --check && python -m compileall -q backend/open_webui",
+        "expected": "Checks complete without errors"
+      },
+      "description": "Run full review, lint, typecheck, tests, and prepare merge only after all findings are closed."
+    }
+  }
+}

--- a/src/lib/apis/admin/billing_reporting.test.ts
+++ b/src/lib/apis/admin/billing_reporting.test.ts
@@ -1,0 +1,63 @@
+// @vitest-environment jsdom
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+
+vi.hoisted(() => {
+	(globalThis as typeof globalThis & { APP_VERSION: string }).APP_VERSION = 'test';
+	(globalThis as typeof globalThis & { APP_BUILD_HASH: string }).APP_BUILD_HASH = 'test';
+});
+import {
+	getBillingReportingCustomers,
+	getBillingReportingExportUrl
+} from './billing_reporting';
+
+describe('billing reporting API', () => {
+	beforeEach(() => {
+		vi.stubGlobal(
+			'fetch',
+			vi.fn().mockResolvedValue({
+				ok: true,
+				json: async () => ({ items: [], total: 0 })
+			})
+		);
+	});
+
+	afterEach(() => {
+		vi.unstubAllGlobals();
+		vi.restoreAllMocks();
+	});
+
+	it('sends currency and date filters to customer reporting', async () => {
+		await getBillingReportingCustomers('token', {
+			currency: 'USD',
+			from: 100,
+			to: 200,
+			page: 2,
+			page_size: 50
+		});
+
+		expect(fetch).toHaveBeenCalledWith(
+			expect.stringContaining(
+				'/admin/billing/reporting/customers?currency=USD&from=100&to=200&page=2&page_size=50'
+			),
+			expect.objectContaining({ headers: { Authorization: 'Bearer token' } })
+		);
+	});
+
+	it('builds bounded export URLs with the active reporting context', () => {
+		const url = getBillingReportingExportUrl({
+			dataset: 'payments',
+			currency: 'EUR',
+			from: 100,
+			to: 200,
+			user_id: 'user/1',
+			status: 'succeeded'
+		});
+
+		expect(url).toContain('dataset=payments');
+		expect(url).toContain('currency=EUR');
+		expect(url).toContain('from=100');
+		expect(url).toContain('to=200');
+		expect(url).toContain('user_id=user%2F1');
+		expect(url).toContain('status=succeeded');
+	});
+});

--- a/src/routes/(app)/admin/billing/+page.svelte
+++ b/src/routes/(app)/admin/billing/+page.svelte
@@ -73,6 +73,13 @@
 				['Bonus balance', overview.metrics.included_balance_kopeks, 'Included/bonus funds; not cash']
 			]
 			: [];
+	$: reportingQuery = new URLSearchParams(
+		Object.entries({
+			currency,
+			from_date: fromDate,
+			to_date: toDate
+		}).filter(([, value]) => value)
+		).toString();
 </script>
 
 <svelte:head><title>{$i18n.t('Billing overview')} • {$WEBUI_NAME}</title></svelte:head>
@@ -119,7 +126,7 @@
 					<div class="overflow-x-auto"><table class="w-full text-left text-sm"><caption class="sr-only">{$i18n.t('Daily payments and usage spend')}</caption><thead class="text-xs text-gray-500"><tr><th class="pb-2">{$i18n.t('Date')}</th><th class="pb-2 text-right">{$i18n.t('Paid')}</th><th class="pb-2 text-right">{$i18n.t('Usage')}</th><th class="pb-2 pl-4">{$i18n.t('Movement')}</th></tr></thead><tbody>{#each overview.series as item}<tr class="border-t border-gray-100 dark:border-gray-800"><td class="py-2 tabular-nums">{item.date}</td><td class="py-2 text-right tabular-nums">{money(item.paid_kopeks)}</td><td class="py-2 text-right tabular-nums">{money(item.usage_kopeks)}</td><td class="w-1/3 py-2 pl-4"><div class="flex gap-1" aria-label={`${item.date}: ${money(item.paid_kopeks)} paid, ${money(item.usage_kopeks)} usage`}><span class="h-2 rounded bg-emerald-500" style={`width:${(item.paid_kopeks / maxSeries) * 100}%`}></span><span class="h-2 rounded bg-blue-500" style={`width:${(item.usage_kopeks / maxSeries) * 100}%`}></span></div></td></tr>{/each}</tbody></table></div>
 				{/if}
 			</section>
-			<section class="rounded-xl border border-gray-200 bg-white p-4 dark:border-gray-800 dark:bg-gray-900"><h2 class="font-medium text-gray-900 dark:text-white">{$i18n.t('Needs attention')}</h2><div class="mt-3 space-y-3 text-sm"><div class="flex justify-between"><span>{$i18n.t('Negative balances')}</span><strong>{overview.warnings.negative_balances}</strong></div><div class="flex justify-between"><span>{$i18n.t('Pending over 24h')}</span><strong>{overview.warnings.stale_pending_payments}</strong></div><div class="flex justify-between"><span>{$i18n.t('Paid without ledger')}</span><strong>{overview.warnings.successful_topups_without_ledger}</strong></div></div><p class="mt-5 text-xs leading-5 text-gray-400">{$i18n.t('Warnings are read-only reconciliation signals. Corrective actions remain in the guarded wallet flow.')}</p><div class="mt-4 flex gap-2"><a class="rounded-lg bg-gray-900 px-3 py-2 text-sm text-white dark:bg-white dark:text-gray-900" href="/admin/billing/customers">{$i18n.t('View customers')}</a><a class="rounded-lg border border-gray-200 px-3 py-2 text-sm dark:border-gray-700" href="/admin/billing/transactions">{$i18n.t('View transactions')}</a></div></section>
+			<section class="rounded-xl border border-gray-200 bg-white p-4 dark:border-gray-800 dark:bg-gray-900"><h2 class="font-medium text-gray-900 dark:text-white">{$i18n.t('Needs attention')}</h2><div class="mt-3 space-y-3 text-sm"><div class="flex justify-between"><span>{$i18n.t('Negative balances')}</span><strong>{overview.warnings.negative_balances}</strong></div><div class="flex justify-between"><span>{$i18n.t('Pending over 24h')}</span><strong>{overview.warnings.stale_pending_payments}</strong></div><div class="flex justify-between"><span>{$i18n.t('Paid without ledger')}</span><strong>{overview.warnings.successful_topups_without_ledger}</strong></div></div><p class="mt-5 text-xs leading-5 text-gray-400">{$i18n.t('Warnings are read-only reconciliation signals. Corrective actions remain in the guarded wallet flow.')}</p><div class="mt-4 flex gap-2"><a class="rounded-lg bg-gray-900 px-3 py-2 text-sm text-white dark:bg-white dark:text-gray-900" href={`/admin/billing/customers?${reportingQuery}`}>{$i18n.t('View customers')}</a><a class="rounded-lg border border-gray-200 px-3 py-2 text-sm dark:border-gray-700" href={`/admin/billing/transactions?${reportingQuery}`}>{$i18n.t('View transactions')}</a></div></section>
 		</div>
 		<p class="mt-4 text-xs text-gray-400">{$i18n.t('As of')} {dateTime(overview.as_of)} · {$i18n.t('Paid time uses provider processing fallback until paid_at is persisted.')}</p>
 	</div>

--- a/src/routes/(app)/admin/billing/customers/+page.svelte
+++ b/src/routes/(app)/admin/billing/customers/+page.svelte
@@ -3,6 +3,7 @@
 	import type { Readable } from 'svelte/store';
 	import type { i18n as I18nType } from 'i18next';
 	import { goto } from '$app/navigation';
+	import { page as pageStore } from '$app/stores';
 	import { WEBUI_NAME, user } from '$lib/stores';
 	import Spinner from '$lib/components/common/Spinner.svelte';
 	import {
@@ -23,18 +24,30 @@
 	let total = 0;
 	let sort: ReportingSort = 'last_payment';
 	let direction: 'asc' | 'desc' = 'desc';
+	let currency = 'RUB';
+	let fromDate = '';
+	let toDate = '';
+	const supportedCurrencies = new Set(['RUB', 'USD', 'EUR']);
 
-	const money = (kopeks: number): string =>
-		new Intl.NumberFormat($i18n.language, { style: 'currency', currency: 'RUB', maximumFractionDigits: 2 }).format(
+	const money = (kopeks: number, currencyCode = currency): string =>
+		new Intl.NumberFormat($i18n.language, { style: 'currency', currency: currencyCode, maximumFractionDigits: 2 }).format(
 			kopeks / 100
 		);
 	const dateTime = (value: number | null): string => (value ? new Date(value * 1000).toLocaleString($i18n.language) : '—');
+	const epoch = (value: string, end = false): number | undefined => {
+		if (!value) return undefined;
+		const date = new Date(`${value}T${end ? '23:59:59' : '00:00:00'}`);
+		return Number.isNaN(date.getTime()) ? undefined : Math.floor(date.getTime() / 1000);
+	};
 
 	const load = async (): Promise<void> => {
 		loading = true;
 		errorMessage = '';
 		try {
 			const result = await getBillingReportingCustomers(localStorage.token, {
+				currency,
+				from: epoch(fromDate),
+				to: epoch(toDate, true),
 				query: submittedQuery,
 				page,
 				page_size: 50,
@@ -67,11 +80,19 @@
 		await load();
 	};
 
+	const openCustomer = async (userId: string): Promise<void> => {
+		await goto(`/admin/billing/customers/${encodeURIComponent(userId)}`);
+	};
+
 	onMount(async () => {
 		if ($user?.role !== 'admin') {
 			await goto('/');
 			return;
 		}
+		const requestedCurrency = $pageStore.url.searchParams.get('currency');
+		currency = requestedCurrency && supportedCurrencies.has(requestedCurrency) ? requestedCurrency : currency;
+		fromDate = $pageStore.url.searchParams.get('from_date') || '';
+		toDate = $pageStore.url.searchParams.get('to_date') || '';
 		await load();
 		loaded = true;
 	});
@@ -83,8 +104,8 @@
 	<div class="flex h-64 items-center justify-center"><Spinner className="size-5" /></div>
 {:else}
 	<div class="mx-auto max-w-7xl px-4 py-5">
-		<div class="mb-4 flex flex-wrap items-end justify-between gap-3"><div><h1 class="text-xl font-semibold text-gray-900 dark:text-white">{$i18n.t('Customers')}</h1><p class="mt-1 text-sm text-gray-500">{total} {$i18n.t('customers in this view')}</p></div><form class="flex gap-2" on:submit|preventDefault={search}><label class="sr-only" for="customer-search">{$i18n.t('Search customers')}</label><input id="customer-search" bind:value={query} placeholder={$i18n.t('Name, email or ID')} class="w-64 rounded-lg border border-gray-200 bg-white px-3 py-2 text-sm dark:border-gray-700 dark:bg-gray-900" /><button class="rounded-lg bg-gray-900 px-3 py-2 text-sm text-white dark:bg-white dark:text-gray-900">{$i18n.t('Search')}</button></form></div>
+		<div class="mb-4 flex flex-wrap items-end justify-between gap-3"><div><h1 class="text-xl font-semibold text-gray-900 dark:text-white">{$i18n.t('Customers')}</h1><p class="mt-1 text-sm text-gray-500">{total} {$i18n.t('customers in this view')}</p></div><div class="flex flex-wrap items-end gap-2"><label class="text-xs text-gray-500">{$i18n.t('Currency')}<select bind:value={currency} on:change={() => { page = 1; load(); }} class="mt-1 block rounded-lg border border-gray-200 bg-white px-2 py-2 text-sm dark:border-gray-700 dark:bg-gray-900"><option>RUB</option><option>USD</option><option>EUR</option></select></label><label class="text-xs text-gray-500">{$i18n.t('From')}<input bind:value={fromDate} on:change={() => { page = 1; load(); }} type="date" class="mt-1 block rounded-lg border border-gray-200 bg-white px-2 py-2 text-sm dark:border-gray-700 dark:bg-gray-900" /></label><label class="text-xs text-gray-500">{$i18n.t('To')}<input bind:value={toDate} on:change={() => { page = 1; load(); }} type="date" class="mt-1 block rounded-lg border border-gray-200 bg-white px-2 py-2 text-sm dark:border-gray-700 dark:bg-gray-900" /></label><form class="flex gap-2" on:submit|preventDefault={search}><label class="sr-only" for="customer-search">{$i18n.t('Search customers')}</label><input id="customer-search" bind:value={query} placeholder={$i18n.t('Name, email or ID')} class="w-64 rounded-lg border border-gray-200 bg-white px-3 py-2 text-sm dark:border-gray-700 dark:bg-gray-900" /><button type="submit" class="rounded-lg bg-gray-900 px-3 py-2 text-sm text-white dark:bg-white dark:text-gray-900">{$i18n.t('Search')}</button></form></div></div>
 		{#if errorMessage}<div class="mb-4 rounded-xl border border-red-200 bg-red-50 p-4 text-sm text-red-700 dark:border-red-900 dark:bg-red-950/30 dark:text-red-200">{errorMessage} <button class="ml-2 underline" on:click={load}>{$i18n.t('Retry')}</button></div>{/if}
-		<div class="overflow-hidden rounded-xl border border-gray-200 bg-white dark:border-gray-800 dark:bg-gray-900"><div class="overflow-x-auto"><table class="min-w-[1080px] w-full text-left text-sm"><caption class="sr-only">{$i18n.t('Customer financial balances and payment activity')}</caption><thead class="bg-gray-50 text-xs text-gray-500 dark:bg-gray-950"><tr><th scope="col" class="px-4 py-3">{$i18n.t('Customer')}</th><th scope="col" class="px-4 py-3 text-right"><button on:click={() => changeSort('paid')} class="underline-offset-2 hover:underline">{$i18n.t('Paid')}</button></th><th scope="col" class="px-4 py-3 text-right"><button on:click={() => changeSort('spent')} class="underline-offset-2 hover:underline">{$i18n.t('Spent')}</button></th><th scope="col" class="px-4 py-3 text-right"><button on:click={() => changeSort('balance')} class="underline-offset-2 hover:underline">{$i18n.t('Balance')}</button></th><th scope="col" class="px-4 py-3">{$i18n.t('Last payment')}</th><th scope="col" class="px-4 py-3">{$i18n.t('Last usage')}</th><th scope="col" class="px-4 py-3">{$i18n.t('Status')}</th></tr></thead><tbody>{#each rows as row}<tr class="cursor-pointer border-t border-gray-100 hover:bg-gray-50 dark:border-gray-800 dark:hover:bg-gray-850" on:click={() => goto(`/admin/billing/customers/${encodeURIComponent(row.user_id)}`)} on:keydown={(event) => event.key === 'Enter' && goto(`/admin/billing/customers/${encodeURIComponent(row.user_id)}`)} tabindex="0"><td class="px-4 py-3"><div class="font-medium text-gray-900 dark:text-white">{row.name || '—'}</div><div class="text-xs text-gray-500">{row.email}<span class="ml-2 text-gray-400">{row.user_id}</span></div></td><td class="px-4 py-3 text-right tabular-nums">{money(row.paid_kopeks)}<div class="text-xs text-gray-400">{row.successful_payment_count} {$i18n.t('payments')}</div></td><td class="px-4 py-3 text-right tabular-nums">{money(row.spent_kopeks)}<div class="text-xs text-gray-400">{money(row.period_spent_kopeks)} {$i18n.t('period')}</div></td><td class="px-4 py-3 text-right tabular-nums"><div>{money(row.balance_topup_kopeks)}</div><div class="text-xs text-amber-600">+ {money(row.balance_included_kopeks)} {$i18n.t('bonus')}</div></td><td class="px-4 py-3 text-xs tabular-nums">{dateTime(row.last_payment_at)}</td><td class="px-4 py-3 text-xs tabular-nums">{dateTime(row.last_usage_at)}</td><td class="px-4 py-3"><span class={`rounded-full px-2 py-1 text-xs ${row.status === 'negative_balance' ? 'bg-red-100 text-red-700 dark:bg-red-950 dark:text-red-200' : row.status === 'never_paid' ? 'bg-gray-100 text-gray-600 dark:bg-gray-800 dark:text-gray-300' : 'bg-emerald-100 text-emerald-700 dark:bg-emerald-950 dark:text-emerald-200'}`}>{$i18n.t(row.status)}</span></td></tr>{:else}<tr><td colspan="7" class="px-4 py-12 text-center text-sm text-gray-500">{$i18n.t('No customers found')}</td></tr>{/each}</tbody></table></div><div class="flex items-center justify-between border-t border-gray-100 px-4 py-3 text-sm dark:border-gray-800"><span class="text-gray-500">{$i18n.t('Page')} {page} / {totalPages}</span><div class="flex gap-2"><button disabled={page <= 1} on:click={() => { page -= 1; load(); }} class="rounded-lg border border-gray-200 px-3 py-1.5 disabled:opacity-40 dark:border-gray-700">{$i18n.t('Previous')}</button><button disabled={page >= totalPages} on:click={() => { page += 1; load(); }} class="rounded-lg border border-gray-200 px-3 py-1.5 disabled:opacity-40 dark:border-gray-700">{$i18n.t('Next')}</button></div></div></div>
+		<div class="overflow-hidden rounded-xl border border-gray-200 bg-white dark:border-gray-800 dark:bg-gray-900"><div class="overflow-x-auto"><table class="min-w-[1080px] w-full text-left text-sm"><caption class="sr-only">{$i18n.t('Customer financial balances and payment activity')}</caption><thead class="bg-gray-50 text-xs text-gray-500 dark:bg-gray-950"><tr><th scope="col" class="px-4 py-3">{$i18n.t('Customer')}</th><th scope="col" class="px-4 py-3 text-right" aria-sort={sort === 'paid' ? direction === 'asc' ? 'ascending' : 'descending' : 'none'}><button type="button" aria-label={`${$i18n.t('Sort by Paid')}; ${sort === 'paid' ? direction : 'none'}`} on:click={() => changeSort('paid')} class="underline-offset-2 hover:underline">{$i18n.t('Paid')}</button></th><th scope="col" class="px-4 py-3 text-right" aria-sort={sort === 'spent' ? direction === 'asc' ? 'ascending' : 'descending' : 'none'}><button type="button" aria-label={`${$i18n.t('Sort by Spent')}; ${sort === 'spent' ? direction : 'none'}`} on:click={() => changeSort('spent')} class="underline-offset-2 hover:underline">{$i18n.t('Spent')}</button></th><th scope="col" class="px-4 py-3 text-right" aria-sort={sort === 'balance' ? direction === 'asc' ? 'ascending' : 'descending' : 'none'}><button type="button" aria-label={`${$i18n.t('Sort by Balance')}; ${sort === 'balance' ? direction : 'none'}`} on:click={() => changeSort('balance')} class="underline-offset-2 hover:underline">{$i18n.t('Balance')}</button></th><th scope="col" class="px-4 py-3">{$i18n.t('Last payment')}</th><th scope="col" class="px-4 py-3">{$i18n.t('Last usage')}</th><th scope="col" class="px-4 py-3">{$i18n.t('Status')}</th></tr></thead><tbody>{#each rows as row}<tr class="cursor-pointer border-t border-gray-100 hover:bg-gray-50 dark:border-gray-800 dark:hover:bg-gray-850" on:click={() => openCustomer(row.user_id)} on:keydown={(event) => { if (event.key === 'Enter' || event.key === ' ') { event.preventDefault(); openCustomer(row.user_id); } }} role="link" aria-label={`${$i18n.t('Open customer')} ${row.name || row.email || row.user_id}`} tabindex="0"><td class="px-4 py-3"><div class="font-medium text-gray-900 dark:text-white">{row.name || '—'}</div><div class="text-xs text-gray-500">{row.email}<span class="ml-2 text-gray-400">{row.user_id}</span></div></td><td class="px-4 py-3 text-right tabular-nums">{money(row.paid_kopeks, row.currency)}<div class="text-xs text-gray-400">{row.successful_payment_count} {$i18n.t('payments')}</div></td><td class="px-4 py-3 text-right tabular-nums">{money(row.spent_kopeks, row.currency)}<div class="text-xs text-gray-400">{money(row.period_spent_kopeks, row.currency)} {$i18n.t('period')}</div></td><td class="px-4 py-3 text-right tabular-nums"><div>{money(row.balance_topup_kopeks, row.currency)}</div><div class="text-xs text-amber-600">+ {money(row.balance_included_kopeks, row.currency)} {$i18n.t('bonus')}</div></td><td class="px-4 py-3 text-xs tabular-nums">{dateTime(row.last_payment_at)}</td><td class="px-4 py-3 text-xs tabular-nums">{dateTime(row.last_usage_at)}</td><td class="px-4 py-3"><span class={`rounded-full px-2 py-1 text-xs ${row.status === 'negative_balance' ? 'bg-red-100 text-red-700 dark:bg-red-950 dark:text-red-200' : row.status === 'never_paid' ? 'bg-gray-100 text-gray-600 dark:bg-gray-800 dark:text-gray-300' : 'bg-emerald-100 text-emerald-700 dark:bg-emerald-950 dark:text-emerald-200'}`}>{$i18n.t(row.status)}</span></td></tr>{:else}<tr><td colspan="7" class="px-4 py-12 text-center text-sm text-gray-500">{$i18n.t('No customers found')}</td></tr>{/each}</tbody></table></div><div class="flex items-center justify-between border-t border-gray-100 px-4 py-3 text-sm dark:border-gray-800"><span class="text-gray-500">{$i18n.t('Page')} {page} / {totalPages}</span><div class="flex gap-2"><button type="button" disabled={page <= 1} on:click={() => { page -= 1; load(); }} class="rounded-lg border border-gray-200 px-3 py-1.5 disabled:opacity-40 dark:border-gray-700">{$i18n.t('Previous')}</button><button type="button" disabled={page >= totalPages} on:click={() => { page += 1; load(); }} class="rounded-lg border border-gray-200 px-3 py-1.5 disabled:opacity-40 dark:border-gray-700">{$i18n.t('Next')}</button></div></div></div>
 	</div>
 {/if}

--- a/src/routes/(app)/admin/billing/transactions/+page.svelte
+++ b/src/routes/(app)/admin/billing/transactions/+page.svelte
@@ -3,6 +3,7 @@
 	import type { Readable } from 'svelte/store';
 	import type { i18n as I18nType } from 'i18next';
 	import { goto } from '$app/navigation';
+	import { page as pageStore } from '$app/stores';
 	import { WEBUI_NAME, user } from '$lib/stores';
 	import Spinner from '$lib/components/common/Spinner.svelte';
 	import {
@@ -27,22 +28,39 @@
 	let total = 0;
 	let status = '';
 	let userId = '';
+	let currency = 'RUB';
+	let fromDate = '';
+	let toDate = '';
+	const supportedCurrencies = new Set(['RUB', 'USD', 'EUR']);
 
-	const money = (kopeks: number): string => new Intl.NumberFormat($i18n.language, { style: 'currency', currency: 'RUB', maximumFractionDigits: 2 }).format(kopeks / 100);
+	const money = (kopeks: number, currencyCode = currency): string => new Intl.NumberFormat($i18n.language, { style: 'currency', currency: currencyCode, maximumFractionDigits: 2 }).format(kopeks / 100);
 	const dateTime = (value: number | null): string => (value ? new Date(value * 1000).toLocaleString($i18n.language) : '—');
+	const epoch = (value: string, end = false): number | undefined => {
+		if (!value) return undefined;
+		const date = new Date(`${value}T${end ? '23:59:59' : '00:00:00'}`);
+		return Number.isNaN(date.getTime()) ? undefined : Math.floor(date.getTime() / 1000);
+	};
 
 	const load = async (): Promise<void> => {
 		loading = true;
 		errorMessage = '';
 		try {
+			const filters = {
+				currency,
+				from: epoch(fromDate),
+				to: epoch(toDate, true),
+				page,
+				page_size: 50,
+				user_id: userId.trim() || undefined
+			};
 			if (activeTab === 'payments') {
-				const result = await getBillingReportingPayments(localStorage.token, { page, page_size: 50, status: status || undefined, user_id: userId || undefined });
+				const result = await getBillingReportingPayments(localStorage.token, { ...filters, status: status || undefined });
 				payments = result.items; total = result.total; totalPages = Math.max(1, result.total_pages);
 			} else if (activeTab === 'ledger') {
-				const result = await getBillingReportingLedger(localStorage.token, { page, page_size: 50, user_id: userId || undefined });
+				const result = await getBillingReportingLedger(localStorage.token, filters);
 				ledger = result.items; total = result.total; totalPages = Math.max(1, result.total_pages);
 			} else {
-				const result = await getBillingReportingUsage(localStorage.token, { page, page_size: 50, user_id: userId || undefined });
+				const result = await getBillingReportingUsage(localStorage.token, filters);
 				usage = result.items; total = result.total; totalPages = Math.max(1, result.total_pages);
 			}
 		} catch (error) {
@@ -55,10 +73,17 @@
 
 	const selectTab = async (tab: typeof activeTab): Promise<void> => { activeTab = tab; page = 1; await load(); };
 	const exportData = async (): Promise<void> => {
+		if (activeTab !== 'payments' && !userId.trim()) {
+			errorMessage = $i18n.t('Enter a user ID to export this view');
+			return;
+		}
 		try {
 			const response = await fetch(getBillingReportingExportUrl({
 				dataset: activeTab,
-				user_id: userId || undefined,
+				currency,
+				from: epoch(fromDate),
+				to: epoch(toDate, true),
+				user_id: userId.trim() || undefined,
 				status: activeTab === 'payments' ? status || undefined : undefined
 			}), { headers: { Authorization: `Bearer ${localStorage.token}` } });
 			if (!response.ok) throw new Error(`Export failed (${response.status})`);
@@ -75,9 +100,60 @@
 		}
 	};
 
-	onMount(async () => { if ($user?.role !== 'admin') { await goto('/'); return; } await load(); loaded = true; });
+	onMount(async () => { if ($user?.role !== 'admin') { await goto('/'); return; } const requestedCurrency = $pageStore.url.searchParams.get('currency'); currency = requestedCurrency && supportedCurrencies.has(requestedCurrency) ? requestedCurrency : currency; fromDate = $pageStore.url.searchParams.get('from_date') || ''; toDate = $pageStore.url.searchParams.get('to_date') || ''; await load(); loaded = true; });
 </script>
 
 <svelte:head><title>{$i18n.t('Billing transactions')} • {$WEBUI_NAME}</title></svelte:head>
 
-{#if !loaded || loading}<div class="flex h-64 items-center justify-center"><Spinner className="size-5" /></div>{:else}<div class="mx-auto max-w-7xl px-4 py-5"><div class="mb-4 flex flex-wrap items-end justify-between gap-3"><div><h1 class="text-xl font-semibold text-gray-900 dark:text-white">{$i18n.t('Transactions')}</h1><p class="mt-1 text-sm text-gray-500">{total} {$i18n.t('events in this view')}</p></div><div class="flex flex-wrap gap-2"><label class="sr-only" for="transaction-user">{$i18n.t('User ID')}</label><input id="transaction-user" bind:value={userId} placeholder={$i18n.t('Filter by user ID')} class="w-48 rounded-lg border border-gray-200 bg-white px-3 py-2 text-sm dark:border-gray-700 dark:bg-gray-900" on:change={() => { page = 1; load(); }} />{#if activeTab === 'payments'}<select bind:value={status} on:change={() => { page = 1; load(); }} class="rounded-lg border border-gray-200 bg-white px-3 py-2 text-sm dark:border-gray-700 dark:bg-gray-900"><option value="">{$i18n.t('All statuses')}</option><option value="succeeded">{$i18n.t('succeeded')}</option><option value="pending">{$i18n.t('pending')}</option><option value="failed">{$i18n.t('failed')}</option><option value="canceled">{$i18n.t('canceled')}</option></select>{/if}<button on:click={exportData} class="rounded-lg border border-gray-200 px-3 py-2 text-sm dark:border-gray-700">{$i18n.t('Export CSV')}</button></div></div>{#if errorMessage}<div class="mb-4 rounded-xl border border-red-200 bg-red-50 p-4 text-sm text-red-700 dark:border-red-900 dark:bg-red-950/30 dark:text-red-200">{errorMessage} <button class="ml-2 underline" on:click={load}>{$i18n.t('Retry')}</button></div>{/if}<div class="rounded-xl border border-gray-200 bg-white dark:border-gray-800 dark:bg-gray-900"><div class="flex gap-1 border-b border-gray-200 p-2 dark:border-gray-800">{#each [['payments', 'Payments'], ['ledger', 'Wallet ledger'], ['usage', 'Usage charges']] as tab}<button class={`rounded-lg px-3 py-2 text-sm ${activeTab === tab[0] ? 'bg-gray-100 font-medium dark:bg-gray-800' : 'text-gray-500'}`} on:click={() => selectTab(tab[0] as typeof activeTab)}>{$i18n.t(tab[1])}</button>{/each}</div><div class="overflow-x-auto p-3">{#if activeTab === 'payments'}<table class="min-w-[900px] w-full text-left text-sm"><thead class="text-xs text-gray-500"><tr><th class="px-2 py-2">{$i18n.t('Time')}</th><th class="px-2 py-2">{$i18n.t('Customer')}</th><th class="px-2 py-2">{$i18n.t('Type')}</th><th class="px-2 py-2">{$i18n.t('Status')}</th><th class="px-2 py-2 text-right">{$i18n.t('Amount')}</th><th class="px-2 py-2">{$i18n.t('Provider')}</th><th class="px-2 py-2">ID</th></tr></thead><tbody>{#each payments as row}<tr class="border-t border-gray-100 dark:border-gray-800"><td class="px-2 py-2 text-xs">{dateTime(row.processed_at)}</td><td class="px-2 py-2"><button class="text-left underline" on:click={() => goto(`/admin/billing/customers/${encodeURIComponent(row.user_id)}`)}>{row.user_id}</button></td><td class="px-2 py-2">{$i18n.t(row.kind)}</td><td class="px-2 py-2">{row.status}</td><td class="px-2 py-2 text-right tabular-nums">{money(row.amount_kopeks)}</td><td class="px-2 py-2">{row.provider}</td><td class="px-2 py-2 font-mono text-xs">{row.id}</td></tr>{:else}<tr><td colspan="7" class="px-2 py-8 text-center text-gray-500">{$i18n.t('No transactions')}</td></tr>{/each}</tbody></table>{:else if activeTab === 'ledger'}<table class="min-w-[950px] w-full text-left text-sm"><thead class="text-xs text-gray-500"><tr><th class="px-2 py-2">{$i18n.t('Time')}</th><th class="px-2 py-2">{$i18n.t('Customer')}</th><th class="px-2 py-2">{$i18n.t('Type')}</th><th class="px-2 py-2 text-right">{$i18n.t('Delta')}</th><th class="px-2 py-2 text-right">{$i18n.t('Balance after')}</th><th class="px-2 py-2">{$i18n.t('Reference')}</th></tr></thead><tbody>{#each ledger as row}<tr class="border-t border-gray-100 dark:border-gray-800"><td class="px-2 py-2 text-xs">{dateTime(Number(row.created_at))}</td><td class="px-2 py-2">{row.name || row.user_id}</td><td class="px-2 py-2">{row.type}</td><td class="px-2 py-2 text-right tabular-nums">{money(Number(row.amount_kopeks))}</td><td class="px-2 py-2 text-right tabular-nums">{money(Number(row.balance_topup_after))}</td><td class="px-2 py-2 font-mono text-xs">{row.reference_id || '—'}</td></tr>{/each}</tbody></table>{:else}<table class="min-w-[1000px] w-full text-left text-sm"><thead class="text-xs text-gray-500"><tr><th class="px-2 py-2">{$i18n.t('Time')}</th><th class="px-2 py-2">{$i18n.t('Customer')}</th><th class="px-2 py-2">{$i18n.t('Model')}</th><th class="px-2 py-2">{$i18n.t('Modality')}</th><th class="px-2 py-2 text-right">{$i18n.t('Charged')}</th><th class="px-2 py-2">{$i18n.t('Source')}</th><th class="px-2 py-2">{$i18n.t('Request')}</th></tr></thead><tbody>{#each usage as row}<tr class="border-t border-gray-100 dark:border-gray-800"><td class="px-2 py-2 text-xs">{dateTime(Number(row.created_at))}</td><td class="px-2 py-2">{row.name || row.user_id}</td><td class="px-2 py-2">{row.model_id}</td><td class="px-2 py-2">{row.modality}</td><td class="px-2 py-2 text-right tabular-nums">{money(Number(row.cost_charged_kopeks))}</td><td class="px-2 py-2">{row.billing_source}</td><td class="px-2 py-2 font-mono text-xs">{row.request_id}</td></tr>{/each}</tbody></table>{/if}</div><div class="flex items-center justify-between border-t border-gray-100 px-4 py-3 text-sm dark:border-gray-800"><span class="text-gray-500">{$i18n.t('Page')} {page} / {totalPages}</span><div class="flex gap-2"><button disabled={page <= 1} on:click={() => { page -= 1; load(); }} class="rounded-lg border border-gray-200 px-3 py-1.5 disabled:opacity-40 dark:border-gray-700">{$i18n.t('Previous')}</button><button disabled={page >= totalPages} on:click={() => { page += 1; load(); }} class="rounded-lg border border-gray-200 px-3 py-1.5 disabled:opacity-40 dark:border-gray-700">{$i18n.t('Next')}</button></div></div></div></div>{/if}
+{#if !loaded || loading}
+	<div class="flex h-64 items-center justify-center"><Spinner className="size-5" /></div>
+{:else}
+	<div class="mx-auto max-w-7xl px-4 py-5">
+		<div class="mb-4 flex flex-wrap items-end justify-between gap-3">
+			<div>
+				<h1 class="text-xl font-semibold text-gray-900 dark:text-white">{$i18n.t('Transactions')}</h1>
+				<p class="mt-1 text-sm text-gray-500">{total} {$i18n.t('events in this view')}</p>
+			</div>
+			<div class="flex flex-wrap items-end gap-2">
+				<label class="text-xs text-gray-500">{$i18n.t('Currency')}
+					<select bind:value={currency} on:change={() => { page = 1; load(); }} class="mt-1 block rounded-lg border border-gray-200 bg-white px-2 py-2 text-sm dark:border-gray-700 dark:bg-gray-900">
+						<option>RUB</option><option>USD</option><option>EUR</option>
+					</select>
+				</label>
+				<label class="text-xs text-gray-500">{$i18n.t('From')}
+					<input bind:value={fromDate} on:change={() => { page = 1; load(); }} type="date" class="mt-1 block rounded-lg border border-gray-200 bg-white px-2 py-2 text-sm dark:border-gray-700 dark:bg-gray-900" />
+				</label>
+				<label class="text-xs text-gray-500">{$i18n.t('To')}
+					<input bind:value={toDate} on:change={() => { page = 1; load(); }} type="date" class="mt-1 block rounded-lg border border-gray-200 bg-white px-2 py-2 text-sm dark:border-gray-700 dark:bg-gray-900" />
+				</label>
+				<label class="sr-only" for="transaction-user">{$i18n.t('User ID')}</label>
+				<input id="transaction-user" bind:value={userId} placeholder={$i18n.t('Filter by user ID')} class="w-48 rounded-lg border border-gray-200 bg-white px-3 py-2 text-sm dark:border-gray-700 dark:bg-gray-900" on:change={() => { page = 1; load(); }} />
+				{#if activeTab === 'payments'}
+					<label class="sr-only" for="transaction-status">{$i18n.t('Payment status')}</label>
+					<select id="transaction-status" bind:value={status} on:change={() => { page = 1; load(); }} class="rounded-lg border border-gray-200 bg-white px-3 py-2 text-sm dark:border-gray-700 dark:bg-gray-900">
+						<option value="">{$i18n.t('All statuses')}</option><option value="succeeded">{$i18n.t('succeeded')}</option><option value="pending">{$i18n.t('pending')}</option><option value="failed">{$i18n.t('failed')}</option><option value="canceled">{$i18n.t('canceled')}</option>
+					</select>
+				{/if}
+				<button type="button" disabled={activeTab !== 'payments' && !userId.trim()} title={activeTab !== 'payments' && !userId.trim() ? $i18n.t('Enter a user ID to export this view') : undefined} on:click={exportData} class="rounded-lg border border-gray-200 px-3 py-2 text-sm disabled:opacity-40 dark:border-gray-700">{$i18n.t('Export CSV')}</button>
+			</div>
+		</div>
+		{#if errorMessage}<div class="mb-4 rounded-xl border border-red-200 bg-red-50 p-4 text-sm text-red-700 dark:border-red-900 dark:bg-red-950/30 dark:text-red-200">{errorMessage} <button type="button" class="ml-2 underline" on:click={load}>{$i18n.t('Retry')}</button></div>{/if}
+		<div class="rounded-xl border border-gray-200 bg-white dark:border-gray-800 dark:bg-gray-900">
+			<div class="flex gap-1 border-b border-gray-200 p-2 dark:border-gray-800" role="tablist" aria-label={$i18n.t('Billing transaction views')}>
+				{#each [['payments', 'Payments'], ['ledger', 'Wallet ledger'], ['usage', 'Usage charges']] as tab}
+					<button type="button" role="tab" aria-selected={activeTab === tab[0]} tabindex={activeTab === tab[0] ? 0 : -1} class={`rounded-lg px-3 py-2 text-sm ${activeTab === tab[0] ? 'bg-gray-100 font-medium dark:bg-gray-800' : 'text-gray-500'}`} on:click={() => selectTab(tab[0] as typeof activeTab)}>{$i18n.t(tab[1])}</button>
+				{/each}
+			</div>
+			<div class="overflow-x-auto p-3">
+				{#if activeTab === 'payments'}
+					<table class="min-w-[900px] w-full text-left text-sm"><caption class="sr-only">{$i18n.t('Provider payments')}</caption><thead class="text-xs text-gray-500"><tr><th scope="col" class="px-2 py-2">{$i18n.t('Time')}</th><th scope="col" class="px-2 py-2">{$i18n.t('Customer')}</th><th scope="col" class="px-2 py-2">{$i18n.t('Type')}</th><th scope="col" class="px-2 py-2">{$i18n.t('Status')}</th><th scope="col" class="px-2 py-2 text-right">{$i18n.t('Amount')}</th><th scope="col" class="px-2 py-2">{$i18n.t('Provider')}</th><th scope="col" class="px-2 py-2">ID</th></tr></thead><tbody>{#each payments as row}<tr class="border-t border-gray-100 dark:border-gray-800"><td class="px-2 py-2 text-xs">{dateTime(row.processed_at)}</td><td class="px-2 py-2"><button type="button" class="text-left underline" on:click={() => goto(`/admin/billing/customers/${encodeURIComponent(row.user_id)}`)}>{row.user_id}</button></td><td class="px-2 py-2">{$i18n.t(row.kind)}</td><td class="px-2 py-2">{row.status}</td><td class="px-2 py-2 text-right tabular-nums">{money(row.amount_kopeks, row.currency)}</td><td class="px-2 py-2">{row.provider}</td><td class="px-2 py-2 font-mono text-xs">{row.id}</td></tr>{:else}<tr><td colspan="7" class="px-2 py-8 text-center text-gray-500">{$i18n.t('No transactions')}</td></tr>{/each}</tbody></table>
+				{:else if activeTab === 'ledger'}
+					<table class="min-w-[950px] w-full text-left text-sm"><caption class="sr-only">{$i18n.t('Wallet ledger entries')}</caption><thead class="text-xs text-gray-500"><tr><th scope="col" class="px-2 py-2">{$i18n.t('Time')}</th><th scope="col" class="px-2 py-2">{$i18n.t('Customer')}</th><th scope="col" class="px-2 py-2">{$i18n.t('Type')}</th><th scope="col" class="px-2 py-2 text-right">{$i18n.t('Delta')}</th><th scope="col" class="px-2 py-2 text-right">{$i18n.t('Balance after')}</th><th scope="col" class="px-2 py-2">{$i18n.t('Reference')}</th></tr></thead><tbody>{#each ledger as row}<tr class="border-t border-gray-100 dark:border-gray-800"><td class="px-2 py-2 text-xs">{dateTime(Number(row.created_at))}</td><td class="px-2 py-2">{row.name || row.user_id}</td><td class="px-2 py-2">{row.type}</td><td class="px-2 py-2 text-right tabular-nums">{money(Number(row.amount_kopeks), typeof row.currency === 'string' ? row.currency : currency)}</td><td class="px-2 py-2 text-right tabular-nums">{money(Number(row.balance_topup_after), typeof row.currency === 'string' ? row.currency : currency)}</td><td class="px-2 py-2 font-mono text-xs">{row.reference_id || '—'}</td></tr>{:else}<tr><td colspan="6" class="px-2 py-8 text-center text-gray-500">{$i18n.t('No ledger entries')}</td></tr>{/each}</tbody></table>
+				{:else}
+					<table class="min-w-[1000px] w-full text-left text-sm"><caption class="sr-only">{$i18n.t('Usage charges')}</caption><thead class="text-xs text-gray-500"><tr><th scope="col" class="px-2 py-2">{$i18n.t('Time')}</th><th scope="col" class="px-2 py-2">{$i18n.t('Customer')}</th><th scope="col" class="px-2 py-2">{$i18n.t('Model')}</th><th scope="col" class="px-2 py-2">{$i18n.t('Modality')}</th><th scope="col" class="px-2 py-2 text-right">{$i18n.t('Charged')}</th><th scope="col" class="px-2 py-2">{$i18n.t('Source')}</th><th scope="col" class="px-2 py-2">{$i18n.t('Request')}</th></tr></thead><tbody>{#each usage as row}<tr class="border-t border-gray-100 dark:border-gray-800"><td class="px-2 py-2 text-xs">{dateTime(Number(row.created_at))}</td><td class="px-2 py-2">{row.name || row.user_id}</td><td class="px-2 py-2">{row.model_id}</td><td class="px-2 py-2">{row.modality}</td><td class="px-2 py-2 text-right tabular-nums">{money(Number(row.cost_charged_kopeks), typeof row.currency === 'string' ? row.currency : currency)}</td><td class="px-2 py-2">{row.billing_source}</td><td class="px-2 py-2 font-mono text-xs">{row.request_id}</td></tr>{:else}<tr><td colspan="7" class="px-2 py-8 text-center text-gray-500">{$i18n.t('No usage charges')}</td></tr>{/each}</tbody></table>
+				{/if}
+			</div>
+			<div class="flex items-center justify-between border-t border-gray-100 px-4 py-3 text-sm dark:border-gray-800"><span class="text-gray-500">{$i18n.t('Page')} {page} / {totalPages}</span><div class="flex gap-2"><button type="button" disabled={page <= 1} on:click={() => { page -= 1; load(); }} class="rounded-lg border border-gray-200 px-3 py-1.5 disabled:opacity-40 dark:border-gray-700">{$i18n.t('Previous')}</button><button type="button" disabled={page >= totalPages} on:click={() => { page += 1; load(); }} class="rounded-lg border border-gray-200 px-3 py-1.5 disabled:opacity-40 dark:border-gray-700">{$i18n.t('Next')}</button></div></div>
+		</div>
+	</div>
+{/if}

--- a/src/routes/(app)/billing/balance/+page.svelte
+++ b/src/routes/(app)/billing/balance/+page.svelte
@@ -4,6 +4,8 @@
 	import { base } from '$app/paths';
 	import { page } from '$app/stores';
 	import { toast } from 'svelte-sonner';
+	import type { Readable } from 'svelte/store';
+	import type { i18n as I18nType } from 'i18next';
 
 	import { WEBUI_NAME, models } from '$lib/stores';
 	import {
@@ -37,7 +39,7 @@
 	} from '$lib/utils/airis/billing_return_url';
 	import { sanitizeReturnTo } from '$lib/utils/airis/return_to';
 
-	const i18n = getContext('i18n');
+	const i18n = getContext<Readable<I18nType>>('i18n');
 
 	const DEFAULT_TOPUP_PACKAGES_KOPEKS = [50000, 100000, 200000];
 	const LOW_BALANCE_THRESHOLD_KOPEKS = 10000;
@@ -455,8 +457,8 @@
 
 			trackEvent('billing_wallet_auto_topup_save', {
 				enabled: autoTopupEnabled,
-				threshold_kopeks: autoTopupEnabled ? threshold : null,
-				amount_kopeks: autoTopupEnabled ? amount : null
+				...(autoTopupEnabled && threshold !== null ? { threshold_kopeks: threshold } : {}),
+				...(autoTopupEnabled && amount !== null ? { amount_kopeks: amount } : {})
 			});
 			toast.success($i18n.t('Auto-topup settings saved'));
 			autoTopupBaseline = {
@@ -514,8 +516,8 @@
 				payload.daily_cap_kopeks = daily;
 
 				trackEvent('billing_wallet_limits_save', {
-					max_reply_cost_kopeks: maxReply,
-					daily_cap_kopeks: daily
+					...(maxReply !== null ? { max_reply_cost_kopeks: maxReply } : {}),
+					...(daily !== null ? { daily_cap_kopeks: daily } : {})
 				});
 			} else {
 				payload.billing_contact_email = contactEmail ? contactEmail : null;
@@ -560,7 +562,7 @@
 		}
 		const amount = kopeks / 100;
 		try {
-			return new Intl.NumberFormat($i18n.locale, {
+		return new Intl.NumberFormat($i18n.language, {
 				style: 'currency',
 				currency
 			}).format(amount);
@@ -695,7 +697,7 @@
 
 	const formatDateTime = (timestamp: number | null | undefined): string => {
 		if (!timestamp) return $i18n.t('Never');
-		return new Date(timestamp * 1000).toLocaleString($i18n.locale, {
+		return new Date(timestamp * 1000).toLocaleString($i18n.language, {
 			year: 'numeric',
 			month: 'long',
 			day: 'numeric',
@@ -718,13 +720,13 @@
 		if (!leadMagnetInfo?.enabled) return false;
 
 		// Prefer server-provided remaining, but keep a local fallback for robustness.
-		const remaining = (leadMagnetInfo.remaining ?? {}) as Record<string, number | undefined>;
+		const remaining = (leadMagnetInfo.remaining ?? {}) as unknown as Record<string, number | undefined>;
 		if (Object.values(remaining).some((value) => typeof value === 'number' && value > 0)) {
 			return true;
 		}
 
-		const quotas = (leadMagnetInfo.quotas ?? {}) as Record<string, number | undefined>;
-		const usage = (leadMagnetInfo.usage ?? {}) as Record<string, number | undefined>;
+		const quotas = (leadMagnetInfo.quotas ?? {}) as unknown as Record<string, number | undefined>;
+		const usage = (leadMagnetInfo.usage ?? {}) as unknown as Record<string, number | undefined>;
 		return Object.entries(quotas).some(([key, limit]) => {
 			if (typeof limit !== 'number' || limit <= 0) return false;
 			const used = usage[key] ?? 0;
@@ -751,7 +753,7 @@
 			<div class="text-gray-500 dark:text-gray-400 text-lg">{errorMessage}</div>
 			<button
 				type="button"
-				on:click={loadBalance}
+				on:click={() => loadBalance()}
 				class="mt-4 px-3 py-1.5 rounded-xl bg-black text-white dark:bg-white dark:text-black transition text-sm font-medium"
 			>
 				{$i18n.t('Retry')}


### PR DESCRIPTION
## Summary

Harden billing payment settlement and retries after the `airis_b2c` follow-up review. The change prevents billable requests from becoming free on settlement errors, persists YooKassa idempotency keys, validates active plans and wallet ownership, bounds reporting/export scope, and improves admin billing filters, currency handling, accessibility, and regression coverage.

## Base Branch Policy

- [x] This PR targets `airis_b2c` (not `main`).

## Workflow Compliance

- [x] Work item spec is created/updated in `meta/memory_bank/specs/work_items/`.
- [x] Branch update is appended in `meta/memory_bank/branch_updates/`.
- [x] For non-trivial changes, SDD spec is linked/updated in `meta/sdd/specs/completed/`.

## Validation

- [ ] Backend checks are green. Targeted sync checks pass; async suite is blocked by the local Docker image missing `pytest-asyncio`.
- [x] Frontend checks are green for the changed scope: Vitest 10/10 and ESLint pass. Full repository typecheck remains red on pre-existing diagnostics outside the changed files.
- [ ] Migration checks are green (if DB touched). No migration was added; Alembic check is blocked by existing metadata drift.
- [x] Security checks are green for the reviewed scope: settlement fail-closed, idempotency, ownership/currency validation, export scoping, and CSV formula protection.
- [x] SDD validation check is green.

## Upstream Impact

Only billing-owned backend services/routers, reporting UI, tests, and workflow documentation are touched. No upstream-owned core files or new dependencies were added.

## Review notes

The already-applied billing migration remains immutable. A separate expiry-bucket ledger migration is intentionally not included in this PR.
