### PR TITLE
fix(landing): remove splash dependency on backend bootstrap

### DIFF
--- a/meta/memory_bank/branch_updates/2026-08-07-codex-bugfix-public-landing-splash.md
+++ b/meta/memory_bank/branch_updates/2026-08-07-codex-bugfix-public-landing-splash.md
@@ -1,0 +1,9 @@
+- [x] **[BUG][UI][LANDING]** Remove backend bootstrap dependency from public landing splash
+  - Spec: `meta/memory_bank/specs/work_items/2026-08-07__bugfix__public-landing-splash.md`
+  - Owner: Codex
+  - Branch: `codex/bugfix/public-landing-splash`
+  - Started: 2026-08-07
+  - Done: 2026-08-07
+  - Summary: Public marketing routes bypass shared backend/session bootstrap so the splash cannot cover the landing page while the API is slow or unavailable; authenticated routes keep the existing path.
+  - Tests: Vitest 102 passed; targeted ESLint passed; Vite build passed; browser smoke `/welcome` and `/auth` passed; `npm run check` remains blocked by 8,355 pre-existing diagnostics.
+  - Risks: Low; guarded route allowlist only changes public marketing startup.

--- a/meta/memory_bank/specs/work_items/2026-08-07__bugfix__public-landing-splash.md
+++ b/meta/memory_bank/specs/work_items/2026-08-07__bugfix__public-landing-splash.md
@@ -1,0 +1,86 @@
+# Public landing splash must not wait for backend bootstrap
+
+## Meta
+
+- Type: bugfix
+- Status: done
+- Owner: Codex
+- Branch: codex/bugfix/public-landing-splash
+- SDD Spec (JSON, required for non-trivial): N/A (targeted frontend guard)
+- Created: 2026-08-07
+- Updated: 2026-08-07
+
+## Context
+
+The public `/welcome` page can remain behind the global splash screen while the shared app layout waits for backend configuration, session, or language bootstrap. Marketing pages are static and should render even when the API is slow or unavailable.
+
+## Goal / Acceptance Criteria
+
+- [x] Public Airis pages remove the splash without waiting for authenticated app bootstrap.
+- [x] Authenticated application routes keep the existing backend/session initialization.
+- [x] Landing smoke test confirms meaningful content renders without framework errors.
+
+## Non-goals
+
+- Changing authenticated session handling.
+- Changing public billing/rate-card API behavior inside the landing page.
+
+## Scope (what changes)
+
+- Backend:
+  - None.
+- Frontend:
+  - Guard shared backend bootstrap by the public marketing route allowlist.
+- Config/Env:
+  - None.
+- Data model / migrations:
+  - None.
+
+## Implementation Notes
+
+- Key files/entrypoints:
+  - `src/routes/+layout.svelte`
+  - `src/lib/utils/airis/public_routes.ts`
+- API changes:
+  - None.
+- Edge cases:
+  - `/auth`, `/signup`, and the authenticated app remain on the existing bootstrap path.
+
+## Upstream impact
+
+- Upstream-owned files touched:
+  - `src/routes/+layout.svelte`
+- Why unavoidable:
+  - The splash lifecycle and backend bootstrap are owned by the root Svelte layout.
+- Minimization strategy (thin hooks / additive modules / guarded behavior):
+  - Keep route classification in an Airis-owned helper and add one guarded branch around existing initialization.
+
+## Verification
+
+- Frontend tests: `npm run test:frontend -- --run` (102 passed)
+- Frontend lint: `npx eslint src/routes/+layout.svelte src/lib/utils/airis/public_routes.ts src/lib/utils/airis/public_routes.test.ts` (passed)
+- Production Vite build: `NODE_OPTIONS=--max-old-space-size=8192 npm run build:vite` (passed; existing Svelte warnings)
+- Rendered smoke: `http://127.0.0.1:5174/welcome` with DOM snapshot, console logs, screenshot, and `/auth` navigation (passed).
+- Typecheck: `npm run check` (blocked by 8,355 pre-existing diagnostics across 349 files).
+
+## Task Entry (for branch_updates/current_tasks)
+
+- [ ] **[BUG][UI][LANDING]** Remove backend bootstrap dependency from public landing splash
+  - Spec: `meta/memory_bank/specs/work_items/2026-08-07__bugfix__public-landing-splash.md`
+  - Owner: Codex
+  - Branch: `codex/bugfix/public-landing-splash`
+  - Started: 2026-08-07
+  - Summary: Public marketing routes now render independently of slow or unavailable backend bootstrap, while authenticated routes retain the existing initialization path.
+  - Tests: Pending
+  - Risks: Low; guarded route allowlist only changes public marketing startup.
+
+## Risks / Rollback
+
+- Risks:
+  - Public pages no longer wait for backend config before first paint, by design.
+- Rollback plan:
+  - Revert the single guarded bootstrap change and helper test.
+
+## Completion Checklist
+
+- [x] Branch update entry moved to `Done` with required fields (`Spec`, `Owner`, `Summary`, `Done`)

--- a/src/lib/utils/airis/public_routes.test.ts
+++ b/src/lib/utils/airis/public_routes.test.ts
@@ -1,0 +1,18 @@
+import { describe, expect, it } from 'vitest';
+
+import { isPublicMarketingRoute } from './public_routes';
+
+describe('isPublicMarketingRoute', () => {
+	it('recognizes public marketing routes and nested documents', () => {
+		expect(isPublicMarketingRoute('/welcome')).toBe(true);
+		expect(isPublicMarketingRoute('/pricing')).toBe(true);
+		expect(isPublicMarketingRoute('/documents/cookies')).toBe(true);
+	});
+
+	it('keeps authenticated and auth routes on the bootstrap path', () => {
+		expect(isPublicMarketingRoute('/')).toBe(false);
+		expect(isPublicMarketingRoute('/auth')).toBe(false);
+		expect(isPublicMarketingRoute('/signup')).toBe(false);
+		expect(isPublicMarketingRoute('/admin/billing')).toBe(false);
+	});
+});

--- a/src/lib/utils/airis/public_routes.ts
+++ b/src/lib/utils/airis/public_routes.ts
@@ -1,0 +1,18 @@
+const PUBLIC_MARKETING_ROUTES = new Set([
+	'/welcome',
+	'/features',
+	'/pricing',
+	'/about',
+	'/contact',
+	'/privacy',
+	'/terms'
+]);
+
+/**
+ * Public marketing pages do not need backend/session bootstrap to render.
+ * Keep the authenticated app and auth routes on the normal initialization path.
+ */
+export const isPublicMarketingRoute = (pathname: string): boolean =>
+	PUBLIC_MARKETING_ROUTES.has(pathname) ||
+	pathname === '/documents' ||
+	pathname.startsWith('/documents/');

--- a/src/routes/+layout.svelte
+++ b/src/routes/+layout.svelte
@@ -17,7 +17,9 @@
 		WEBUI_NAME,
 		WEBUI_VERSION,
 		WEBUI_DEPLOYMENT_ID,
+		appData,
 		mobile,
+		models,
 		socket,
 		socketConnected,
 		chatId,
@@ -62,7 +64,7 @@
 		removeTerminalConnection
 	} from '$lib/utils/connections';
 
-	import { WEBUI_API_BASE_URL, WEBUI_BASE_URL, WEBUI_HOSTNAME } from '$lib/constants';
+	import { WEBUI_API_BASE_URL, WEBUI_BASE_URL } from '$lib/constants';
 	import {
 		bestMatchingLanguage,
 		cleanText,
@@ -70,14 +72,13 @@
 		getUserTimezone,
 		removeAllDetails
 	} from '$lib/utils';
-	import { setTextScale } from '$lib/utils/text-scale';
+	import { isPublicMarketingRoute } from '$lib/utils/airis/public_routes';
 
 	import NotificationToast from '$lib/components/NotificationToast.svelte';
 	import AppSidebar from '$lib/components/app/AppSidebar.svelte';
 	import SyncStatsModal from '$lib/components/chat/Settings/SyncStatsModal.svelte';
 	import Spinner from '$lib/components/common/Spinner.svelte';
 	import { getOutputText } from '$lib/components/chat/Messages/structuredOutput';
-	import { getUserSettings } from '$lib/apis/users';
 	import dayjs from 'dayjs';
 	import { getChannels } from '$lib/apis/channels';
 
@@ -376,9 +377,9 @@
 			worker.removeEventListener('message', onMessage);
 			worker.removeEventListener('error', onError);
 
-			data['stdout'] && (stdout = data['stdout']);
-			data['stderr'] && (stderr = data['stderr']);
-			data['result'] && (result = data['result']);
+			if (data['stdout']) stdout = data['stdout'];
+			if (data['stderr']) stderr = data['stderr'];
+			if (data['result']) result = data['result'];
 
 			if (cb) {
 				cb(
@@ -493,8 +494,6 @@
 	};
 
 	const chatEventHandler = async (event, cb) => {
-		const chat = $page.url.pathname.includes(`/c/${event.chat_id}`);
-
 		// Skip events from temporary chats that are not the current chat.
 		// This prevents notifications from being sent to other tabs/devices
 		// for privacy, since temporary chats are not meant to be persisted or visible elsewhere.
@@ -563,7 +562,7 @@
 				return;
 			} else if (type === 'request:chat:completion') {
 				console.log(data, $socket.id);
-				const { session_id, channel, form_data, model } = data;
+				const { channel, form_data, model } = data;
 
 				try {
 					const directConnections = $settings?.directConnections ?? {};
@@ -581,11 +580,7 @@
 								form_data['model'] = form_data['model'].replace(`${prefixId}.`, ``);
 							}
 
-							const [res, controller] = await chatCompletion(
-								OPENAI_API_KEY,
-								form_data,
-								OPENAI_API_URL
-							);
+							const [res] = await chatCompletion(OPENAI_API_KEY, form_data, OPENAI_API_URL);
 
 							if (res) {
 								// raise if the response is not ok
@@ -604,9 +599,11 @@
 									const decoder = new TextDecoder();
 
 									const processStream = async () => {
-										while (true) {
+										let streamDone = false;
+										while (!streamDone) {
 											// Read data chunks from the response stream
 											const { done, value } = await reader.read();
+											streamDone = done;
 											if (done) {
 												break;
 											}
@@ -710,7 +707,7 @@
 
 		// handle channel created event
 		if (event.data?.type === 'channel:created') {
-			const res = await getChannels(localStorage.token).catch(async (error) => {
+			const res = await getChannels(localStorage.token).catch(() => {
 				return null;
 			});
 
@@ -761,7 +758,7 @@
 						})
 					);
 				} else {
-					const res = await getChannels(localStorage.token).catch(async (error) => {
+					const res = await getChannels(localStorage.token).catch(() => {
 						return null;
 					});
 
@@ -1015,12 +1012,12 @@
 			return nav && (el === nav || nav.contains(el));
 		}
 
-		document.addEventListener('touchstart', (e) => {
+		const touchstartHandler = (e) => {
 			if (!isNavOrDescendant(e.target)) return;
 			touchstartY = e.touches[0].clientY;
-		});
+		};
 
-		document.addEventListener('touchmove', (e) => {
+		const touchmoveHandler = (e) => {
 			if (!isNavOrDescendant(e.target)) return;
 			const touchY = e.touches[0].clientY;
 			const touchDiff = touchY - touchstartY;
@@ -1028,15 +1025,19 @@
 				showRefresh = true;
 				e.preventDefault();
 			}
-		});
+		};
 
-		document.addEventListener('touchend', (e) => {
+		const touchendHandler = (e) => {
 			if (!isNavOrDescendant(e.target)) return;
 			if (showRefresh) {
 				showRefresh = false;
 				location.reload();
 			}
-		});
+		};
+
+		document.addEventListener('touchstart', touchstartHandler);
+		document.addEventListener('touchmove', touchmoveHandler);
+		document.addEventListener('touchend', touchendHandler);
 
 		if (typeof window !== 'undefined') {
 			if (window.applyTheme) {
@@ -1145,82 +1146,82 @@
 			}
 		});
 
-		let backendConfig = null;
-		try {
-			backendConfig = await getBackendConfig();
-			console.log('Backend config:', backendConfig);
-		} catch (error) {
-			if (error?.authRedirect) {
-				// Forward-auth proxy is redirecting to an external login page.
-				// Full-page navigation lets the browser follow the redirect natively.
-				window.location.href = '/';
-				return;
-			}
-			console.error('Error loading backend config:', error);
-		}
-		// Initialize i18n even if we didn't get a backend config,
-		// so `/error` can show something that's not `undefined`.
-
 		initI18n(localStorage?.locale);
-		if (!localStorage.locale) {
-			const languages = await getLanguages();
-			const browserLanguages = navigator.languages
-				? navigator.languages
-				: [navigator.language || navigator.userLanguage];
-			const lang = backendConfig?.default_locale
-				? backendConfig.default_locale
-				: bestMatchingLanguage(languages, browserLanguages, 'en-US');
-			changeLanguage(lang);
-			dayjs.locale(lang);
-		}
+		if (!isPublicMarketingRoute($page.url.pathname)) {
+			let backendConfig = null;
+			try {
+				backendConfig = await getBackendConfig();
+				console.log('Backend config:', backendConfig);
+			} catch (error) {
+				if (error?.authRedirect) {
+					// Forward-auth proxy is redirecting to an external login page.
+					// Full-page navigation lets the browser follow the redirect natively.
+					window.location.href = '/';
+					return;
+				}
+				console.error('Error loading backend config:', error);
+			}
 
-		if (backendConfig) {
-			// Save Backend Status to Store
-			await config.set(backendConfig);
-			await WEBUI_NAME.set(backendConfig.name);
+			if (!localStorage.locale) {
+				const languages = await getLanguages();
+				const browserLanguages = navigator.languages
+					? navigator.languages
+					: [navigator.language || navigator.userLanguage];
+				const lang = backendConfig?.default_locale
+					? backendConfig.default_locale
+					: bestMatchingLanguage(languages, browserLanguages, 'en-US');
+				changeLanguage(lang);
+				dayjs.locale(lang);
+			}
 
-			if ($config) {
-				await setupSocket($config.features?.enable_websocket ?? true);
+			if (backendConfig) {
+				// Save Backend Status to Store
+				await config.set(backendConfig);
+				await WEBUI_NAME.set(backendConfig.name);
 
-				if (localStorage.token) {
-					// Get Session User Info
-					const sessionUser = await getSessionUser(localStorage.token).catch((error) => {
-						toast.error(`${error}`);
-						return null;
-					});
+				if ($config) {
+					await setupSocket($config.features?.enable_websocket ?? true);
 
-					if (sessionUser) {
-						await user.set(sessionUser);
-						try {
-							await config.set(await getBackendConfig());
-						} catch (error) {
-							console.error('Error refreshing backend config:', error);
+					if (localStorage.token) {
+						// Get Session User Info
+						const sessionUser = await getSessionUser(localStorage.token).catch((error) => {
+							toast.error(`${error}`);
+							return null;
+						});
+
+						if (sessionUser) {
+							await user.set(sessionUser);
+							try {
+								await config.set(await getBackendConfig());
+							} catch (error) {
+								console.error('Error refreshing backend config:', error);
+							}
+
+							// Keep user timezone in sync on every app load/refresh
+							const timezone = getUserTimezone();
+							if (timezone) {
+								updateUserTimezone(localStorage.token, timezone);
+							}
+
+							// Relay auth token to desktop app for API access
+							if (window.electronAPI?.send) {
+								window.electronAPI
+									.send({
+										type: 'token:update',
+										token: localStorage.token
+									})
+									.catch(() => {});
+							}
+						} else {
+							localStorage.removeItem('token');
+							await user.set(null);
 						}
-
-						// Keep user timezone in sync on every app load/refresh
-						const timezone = getUserTimezone();
-						if (timezone) {
-							updateUserTimezone(localStorage.token, timezone);
-						}
-
-						// Relay auth token to desktop app for API access
-						if (window.electronAPI?.send) {
-							window.electronAPI
-								.send({
-									type: 'token:update',
-									token: localStorage.token
-								})
-								.catch(() => {});
-						}
-					} else {
-						localStorage.removeItem('token');
-						await user.set(null);
 					}
 				}
+			} else {
+				// Redirect to /error when Backend Not Detected
+				await goto(`/error`);
 			}
-		} else {
-			// Redirect to /error when Backend Not Detected
-			await goto(`/error`);
 		}
 
 		await tick();


### PR DESCRIPTION
## Bug
The local/public `/welcome` page could stay on the black splash screen indefinitely while the shared root layout waited for backend configuration, session, or language bootstrap.

## Root cause
Marketing routes were forced through authenticated app initialization before the splash was removed. A slow/unavailable API therefore blocked the first meaningful paint.

## Fix
- Added a small Airis-owned public-route classifier for marketing pages and nested legal documents.
- Skip backend/session/socket bootstrap on those routes; i18n still initializes for shared chrome.
- Keep `/auth`, `/signup`, `/`, and authenticated app routes on the existing bootstrap path.
- Fixed missing root-layout store imports and named touch handlers so cleanup/runtime paths remain valid and the changed file passes lint.

## Verification
- `npm run test:frontend -- --run` — 102 passed
- Targeted ESLint — passed
- `NODE_OPTIONS=--max-old-space-size=8192 npm run build:vite` — passed
- Browser smoke at `http://127.0.0.1:5174/welcome` — hero rendered, splash absent, no console errors/warnings
- Browser smoke at `/auth` — auth screen rendered, splash absent, no console errors/warnings
- `npm run check` — blocked by existing 8,355 diagnostics across 349 unrelated files
- `git diff --check` — passed

## Risk
Low. The change is guarded by a narrow public marketing allowlist; authenticated initialization is unchanged.
