### PR TITLE
fix(landing): preserve auth CTA on public pages

### DIFF
--- a/meta/memory_bank/branch_updates/2026-08-07-codex-bugfix-public-landing-auth-cta.md
+++ b/meta/memory_bank/branch_updates/2026-08-07-codex-bugfix-public-landing-auth-cta.md
@@ -1,0 +1,10 @@
+# Public landing auth CTA fallback
+
+Spec: `meta/memory_bank/specs/work_items/2026-08-07__bugfix__public-landing-auth-cta.md`
+
+- [x] Added non-blocking public session hydration.
+- [x] Added token fallback for landing CTAs.
+- [x] Added `/prices` to the public route allowlist.
+- [x] Ran targeted lint/tests and diff checks.
+
+Done: 2026-08-07

--- a/meta/memory_bank/specs/work_items/2026-08-07__bugfix__public-landing-auth-cta.md
+++ b/meta/memory_bank/specs/work_items/2026-08-07__bugfix__public-landing-auth-cta.md
@@ -1,0 +1,27 @@
+# Public landing session CTA fallback
+
+Status: done
+Type: bug fix
+
+## Problem
+
+Public pages render without waiting for backend bootstrap, but an existing token can leave the session store empty briefly. Landing CTAs then send an authenticated user to signup.
+
+## Change
+
+- Hydrate an existing public-page session asynchronously without blocking first paint.
+- Treat an existing browser token as an authenticated CTA fallback until hydration completes.
+- Include the legacy `/prices` route in the public allowlist.
+
+## Acceptance criteria
+
+- [x] Public routes still render without backend bootstrap.
+- [x] Authenticated CTA navigation goes to chat during session hydration.
+- [x] `/prices` does not wait for backend bootstrap.
+- [x] Targeted landing tests and lint pass.
+
+## Validation
+
+- `npx eslint src/routes/+layout.svelte src/lib/components/landing/welcomeNavigation.ts src/lib/components/landing/welcomeNavigation.test.ts src/lib/utils/airis/public_routes.ts src/lib/utils/airis/public_routes.test.ts`
+- `npx vitest run src/lib/components/landing/welcomeNavigation.test.ts src/lib/components/landing/welcomeLandingLinks.test.ts src/lib/utils/airis/public_routes.test.ts` (10 passed)
+- `git diff --check`

--- a/src/lib/components/landing/welcomeNavigation.test.ts
+++ b/src/lib/components/landing/welcomeNavigation.test.ts
@@ -39,6 +39,7 @@ describe('welcomeNavigation', () => {
 	beforeEach(() => {
 		gotoMock.mockReset();
 		sessionStorage.clear();
+		localStorage.removeItem('token');
 		userStore.set(null);
 	});
 
@@ -99,6 +100,14 @@ describe('welcomeNavigation', () => {
 		const redirect = parsed.searchParams.get('redirect');
 		const redirectUrl = parseUrl(redirect ?? '');
 		expect(redirectUrl.searchParams.get('src')).toBe('welcome_cta');
+	});
+
+	it('openCta uses an existing token before session hydration completes', () => {
+		localStorage.setItem('token', 'session-token');
+
+		openCta('welcome_cta');
+
+		expect(gotoMock).toHaveBeenCalledWith('/?src=welcome_cta');
 	});
 
 	it('openPreset stores guest prompt and redirects to signup', () => {

--- a/src/lib/components/landing/welcomeNavigation.ts
+++ b/src/lib/components/landing/welcomeNavigation.ts
@@ -23,10 +23,12 @@ export const buildSignupUrl = (source: string, params: Record<string, string> = 
 	return `/signup?${searchParams.toString()}`;
 };
 
+const hasActiveSession = (): boolean => Boolean(get(user) || (browser && localStorage.token));
+
 export const openPreset = (source: string, preset: string, prompt: string): void => {
 	const target = buildChatUrl(source, { preset, q: prompt, submit: 'false' });
 
-	if (get(user)) {
+	if (hasActiveSession()) {
 		goto(target);
 		return;
 	}
@@ -55,7 +57,7 @@ export const openPreset = (source: string, preset: string, prompt: string): void
 export const openCta = (source: string): void => {
 	const target = buildChatUrl(source);
 
-	if (get(user)) {
+	if (hasActiveSession()) {
 		goto(target);
 		return;
 	}

--- a/src/lib/utils/airis/public_routes.test.ts
+++ b/src/lib/utils/airis/public_routes.test.ts
@@ -1,15 +1,15 @@
 import { describe, expect, it } from 'vitest';
-
 import { isPublicMarketingRoute } from './public_routes';
 
 describe('isPublicMarketingRoute', () => {
-	it('recognizes public marketing routes and nested documents', () => {
+	it('allows public marketing routes and legacy prices alias', () => {
 		expect(isPublicMarketingRoute('/welcome')).toBe(true);
 		expect(isPublicMarketingRoute('/pricing')).toBe(true);
-		expect(isPublicMarketingRoute('/documents/cookies')).toBe(true);
+		expect(isPublicMarketingRoute('/prices')).toBe(true);
+		expect(isPublicMarketingRoute('/documents/example')).toBe(true);
 	});
 
-	it('keeps authenticated and auth routes on the bootstrap path', () => {
+	it('keeps authenticated app and auth routes on normal bootstrap', () => {
 		expect(isPublicMarketingRoute('/')).toBe(false);
 		expect(isPublicMarketingRoute('/auth')).toBe(false);
 		expect(isPublicMarketingRoute('/signup')).toBe(false);

--- a/src/lib/utils/airis/public_routes.ts
+++ b/src/lib/utils/airis/public_routes.ts
@@ -2,6 +2,7 @@ const PUBLIC_MARKETING_ROUTES = new Set([
 	'/welcome',
 	'/features',
 	'/pricing',
+	'/prices',
 	'/about',
 	'/contact',
 	'/privacy',

--- a/src/routes/+layout.svelte
+++ b/src/routes/+layout.svelte
@@ -1147,7 +1147,16 @@
 		});
 
 		initI18n(localStorage?.locale);
-		if (!isPublicMarketingRoute($page.url.pathname)) {
+		const isPublicRoute = isPublicMarketingRoute($page.url.pathname);
+		if (isPublicRoute && localStorage.token) {
+			// Hydrate an existing session without delaying the public landing page.
+			void getSessionUser(localStorage.token)
+				.then((sessionUser) => {
+					if (sessionUser) user.set(sessionUser);
+				})
+				.catch((error) => console.warn('Unable to hydrate public session:', error));
+		}
+		if (!isPublicRoute) {
 			let backendConfig = null;
 			try {
 				backendConfig = await getBackendConfig();


### PR DESCRIPTION
## Summary
- hydrate an existing public-page session without blocking the landing first paint
- route CTAs directly to chat when a token exists while hydration is pending
- keep legacy `/prices` on the public route path

## Validation
- targeted ESLint passed
- 10 targeted landing/public-route Vitest tests passed
- `git diff --check` passed

## Review note
This follows the merged splash fix and closes the authenticated-user CTA race before production rollout.
