### PR TITLE
refactor: unify Airis public page design

### DIFF
--- a/meta/memory_bank/branch_updates/2026-08-07-codex-redesign-public-pages.md
+++ b/meta/memory_bank/branch_updates/2026-08-07-codex-redesign-public-pages.md
@@ -1,0 +1,10 @@
+### Done
+
+- [x] **[REFACTOR][UI][PUBLIC]** Centralize Airis public-page design system
+  - Spec: `meta/memory_bank/specs/work_items/2026-08-07__refactor__public-airis-design-system.md`
+  - Owner: Codex
+  - Branch: `codex/redesign/public-pages`
+  - Done: 2026-08-07
+  - Summary: Unify public and legal routes around the Airis deep-violet shell, shared navigation/CTA/footer tokens, and consistent brand spelling without changing product behavior or legal copy.
+  - Tests: `git diff --check`; `npm run check` (pre-existing repo-wide diagnostics); `npm run build:vite` (local heap limit); in-app route smoke test passed.
+  - Risks: Low-Medium (shared public shell CSS); mitigated by scoping styles to public route boundaries and visual route checks.

--- a/meta/memory_bank/specs/work_items/2026-08-07__refactor__public-airis-design-system.md
+++ b/meta/memory_bank/specs/work_items/2026-08-07__refactor__public-airis-design-system.md
@@ -1,0 +1,66 @@
+# Centralize Airis public-page design system
+
+## Meta
+
+- Type: refactor
+- Status: done
+- Owner: Codex
+- Branch: codex/redesign/public-pages
+- SDD Spec (JSON, required for non-trivial): `meta/sdd/specs/completed/public-airis-design-system-2026-08-07-001.json`
+- Created: 2026-08-07
+- Updated: 2026-08-07
+
+## Context
+
+`/welcome` already uses the current Airis dark-violet visual language, while the remaining public and legal routes use independent light gray/black utility styles. That makes the navigation, CTA hierarchy, typography, surfaces, and footer feel like different products. A route audit also found that `PublicPageLayout` did not pass its tone to `FooterLinks`, so the footer could silently use the wrong theme.
+
+## Goal / Acceptance Criteria
+
+- [x] Define one scoped Airis token layer for public pages (deep violet canvas, lavender accent, readable muted text, consistent borders and motion).
+- [x] Use the same navigation, CTA, focus, footer, and brand spelling (`Airis`) on all public/legal routes.
+- [x] Preserve real product screenshots, route behavior, API-backed pricing/model data, and legal copy.
+- [x] Keep intentional product UI contrast (dark screenshots/cards) without leaking public styles into the app shell.
+- [x] Smoke-test `/welcome`, marketing pages, the document index, canonical legal routes, and nested documents.
+
+## Non-goals
+
+- No new dependencies, API changes, copy claims, legal-text edits, or auth-flow rewrite in this pass.
+- No redesign of authenticated chat/admin screens beyond the scoped shared public components.
+
+## Scope (what changes)
+
+- Backend: none.
+- Frontend: shared `publicTheme.css`, `PublicPageLayout`, `NavHeader`, and `FooterLinks`.
+- Config/Env: none.
+- Data model / migrations: none.
+
+## Implementation Notes
+
+- `publicTheme.css` is imported once from `src/app.css` and is scoped to `.airis-public-page` plus shared public nav/footer classes.
+- The route markup remains intentionally stable; centralized selectors normalize legacy gray/white surfaces and keep public pages on the same deep-violet canvas.
+- `PublicPageLayout` now defaults to the shared dark tone, passes `tone` into `FooterLinks`, and uses `Airis` in metadata/copyright.
+- `NavHeader` uses semantic shared classes for desktop/mobile links and primary actions while retaining existing auth redirect and analytics behavior.
+
+## Upstream impact
+
+- Upstream-owned frontend components touched: `PublicPageLayout.svelte`, `NavHeader.svelte`, and `FooterLinks.svelte`.
+- Why unavoidable: these are the existing public shell boundaries used by every marketing/legal route.
+- Minimization strategy: additive scoped CSS plus small class/prop changes; route content and app/admin styling are untouched.
+
+## Verification
+
+- `git diff --check`
+- `npm run check` (currently reports pre-existing repository-wide type errors; no new diagnostics in the changed shell files)
+- `npm run build:vite` (currently reaches chunk rendering but exceeds the local Node heap; rerun with an increased heap in CI/local verification)
+- In-app browser smoke test at 1280px: `/welcome`, `/features`, `/pricing`, `/about`, `/contact`, `/documents`, `/terms`, `/privacy`, and all six nested document routes.
+
+## Risks / Rollback
+
+- Risks: global public selectors could affect a new marketing component if it is not nested in `.airis-public-page`; intentional contrast surfaces should keep explicit arbitrary colors.
+- Rollback plan: revert the scoped theme import and the three shell component diffs; route behavior and content remain unchanged.
+
+## Completion Checklist
+
+- [x] `meta/tools/sdd check-complete public-airis-design-system-2026-08-07-001 --json`
+- [x] `meta/tools/sdd complete-spec public-airis-design-system-2026-08-07-001 --json`
+- [x] Branch update entry moved to `Done` with required fields.

--- a/meta/sdd/specs/completed/public-airis-design-system-2026-08-07-001.json
+++ b/meta/sdd/specs/completed/public-airis-design-system-2026-08-07-001.json
@@ -1,0 +1,199 @@
+{
+  "spec_id": "public-airis-design-system-2026-08-07-001",
+  "title": "public-airis-design-system",
+  "generated": "2026-08-07T13:13:06.657206Z",
+  "last_updated": "2026-08-07T13:14:58.292205Z",
+  "metadata": {
+    "template": "medium",
+    "complexity": "medium",
+    "risk_level": "medium",
+    "estimated_hours": 24,
+    "security_sensitive": false,
+    "default_category": "implementation",
+    "work_item_spec": "meta/memory_bank/specs/work_items/2026-08-07__refactor__public-airis-design-system.md",
+    "status": "completed",
+    "activated_date": "2026-08-07T13:13:22.160103Z",
+    "progress_percentage": 100,
+    "completed_date": "2026-08-07T13:14:58.291826Z"
+  },
+  "hierarchy": {
+    "spec-root": {
+      "type": "spec",
+      "title": "public-airis-design-system",
+      "status": "completed",
+      "parent": null,
+      "children": [
+        "phase-1",
+        "phase-2",
+        "phase-3"
+      ],
+      "total_tasks": 3,
+      "completed_tasks": 3,
+      "metadata": {}
+    },
+    "phase-1": {
+      "type": "phase",
+      "title": "Phase 1: Centralize public tokens and shell",
+      "status": "completed",
+      "parent": "spec-root",
+      "children": [
+        "task-1-1"
+      ],
+      "total_tasks": 1,
+      "completed_tasks": 1,
+      "metadata": {
+        "needs_journaling": false,
+        "completed_at": "2026-08-07T13:14:33.612273Z",
+        "journaled_at": "2026-08-07T13:14:33.614995Z"
+      }
+    },
+    "phase-2": {
+      "type": "phase",
+      "title": "Phase 2: Migrate public and legal routes",
+      "status": "completed",
+      "parent": "spec-root",
+      "children": [
+        "task-2-1"
+      ],
+      "total_tasks": 1,
+      "completed_tasks": 1,
+      "metadata": {
+        "needs_journaling": false,
+        "completed_at": "2026-08-07T13:14:34.236435Z",
+        "journaled_at": "2026-08-07T13:14:34.239171Z"
+      }
+    },
+    "phase-3": {
+      "type": "phase",
+      "title": "Phase 3: Visual and route verification",
+      "status": "completed",
+      "parent": "spec-root",
+      "children": [
+        "task-3-1"
+      ],
+      "total_tasks": 1,
+      "completed_tasks": 1,
+      "metadata": {
+        "needs_journaling": false,
+        "completed_at": "2026-08-07T13:14:34.801475Z",
+        "journaled_at": "2026-08-07T13:14:34.804301Z"
+      }
+    },
+    "task-1-1": {
+      "type": "task",
+      "title": "Centralize public tokens and shell",
+      "status": "completed",
+      "parent": "phase-1",
+      "children": [],
+      "dependencies": {
+        "blocks": [],
+        "blocked_by": [],
+        "depends": []
+      },
+      "total_tasks": 1,
+      "completed_tasks": 1,
+      "metadata": {
+        "completed_at": "2026-08-07T13:14:33.612058Z",
+        "needs_journaling": false,
+        "status_note": "Added scoped publicTheme.css and switched the shared layout/nav/footer to semantic Airis classes.",
+        "journaled_at": "2026-08-07T13:14:33.613465Z"
+      }
+    },
+    "task-2-1": {
+      "type": "task",
+      "title": "Migrate public and legal routes to the shared system",
+      "status": "completed",
+      "parent": "phase-2",
+      "children": [],
+      "dependencies": {
+        "blocks": [],
+        "blocked_by": [],
+        "depends": []
+      },
+      "total_tasks": 1,
+      "completed_tasks": 1,
+      "metadata": {
+        "completed_at": "2026-08-07T13:14:34.236230Z",
+        "needs_journaling": false,
+        "status_note": "All public/legal routes inherit the centralized deep-violet shell without route-copy or behavior changes.",
+        "journaled_at": "2026-08-07T13:14:34.237581Z"
+      }
+    },
+    "task-3-1": {
+      "type": "task",
+      "title": "Run visual and route verification",
+      "status": "completed",
+      "parent": "phase-3",
+      "children": [],
+      "dependencies": {
+        "blocks": [],
+        "blocked_by": [],
+        "depends": []
+      },
+      "total_tasks": 1,
+      "completed_tasks": 1,
+      "metadata": {
+        "completed_at": "2026-08-07T13:14:34.801238Z",
+        "needs_journaling": false,
+        "status_note": "In-app browser smoke-tested canonical and nested public/legal routes; captured feature, pricing, and terms screenshots.",
+        "journaled_at": "2026-08-07T13:14:34.802655Z"
+      }
+    }
+  },
+  "journal": [
+    {
+      "timestamp": "2026-08-07T13:14:33.613458Z",
+      "entry_type": "status_change",
+      "title": "Task Completed: Centralize public tokens and shell",
+      "author": "claude-code",
+      "content": "Task task-1-1 marked as completed. \nNote: Added scoped publicTheme.css and switched the shared layout/nav/footer to semantic Airis classes.",
+      "metadata": {},
+      "task_id": "task-1-1"
+    },
+    {
+      "timestamp": "2026-08-07T13:14:33.614989Z",
+      "entry_type": "status_change",
+      "title": "Phase Completed: Phase 1: Centralize public tokens and shell",
+      "author": "claude-code",
+      "content": "All child tasks in phase phase-1 have been completed.",
+      "metadata": {},
+      "task_id": "phase-1"
+    },
+    {
+      "timestamp": "2026-08-07T13:14:34.237571Z",
+      "entry_type": "status_change",
+      "title": "Task Completed: Migrate public and legal routes to the shared system",
+      "author": "claude-code",
+      "content": "Task task-2-1 marked as completed. \nNote: All public/legal routes inherit the centralized deep-violet shell without route-copy or behavior changes.",
+      "metadata": {},
+      "task_id": "task-2-1"
+    },
+    {
+      "timestamp": "2026-08-07T13:14:34.239165Z",
+      "entry_type": "status_change",
+      "title": "Phase Completed: Phase 2: Migrate public and legal routes",
+      "author": "claude-code",
+      "content": "All child tasks in phase phase-2 have been completed.",
+      "metadata": {},
+      "task_id": "phase-2"
+    },
+    {
+      "timestamp": "2026-08-07T13:14:34.802646Z",
+      "entry_type": "status_change",
+      "title": "Task Completed: Run visual and route verification",
+      "author": "claude-code",
+      "content": "Task task-3-1 marked as completed. \nNote: In-app browser smoke-tested canonical and nested public/legal routes; captured feature, pricing, and terms screenshots.",
+      "metadata": {},
+      "task_id": "task-3-1"
+    },
+    {
+      "timestamp": "2026-08-07T13:14:34.804295Z",
+      "entry_type": "status_change",
+      "title": "Phase Completed: Phase 3: Visual and route verification",
+      "author": "claude-code",
+      "content": "All child tasks in phase phase-3 have been completed.",
+      "metadata": {},
+      "task_id": "phase-3"
+    }
+  ]
+}

--- a/src/app.css
+++ b/src/app.css
@@ -1,3 +1,5 @@
+@import './lib/components/landing/publicTheme.css';
+
 @reference "./tailwind.css";
 
 @font-face {

--- a/src/lib/components/landing/FooterLinks.svelte
+++ b/src/lib/components/landing/FooterLinks.svelte
@@ -14,13 +14,13 @@
 		{ href: '/privacy', label: 'Политика конфиденциальности' }
 	];
 
-	export let copyright: string = `${new Date().getFullYear()} AIris. Все права защищены.`;
+	export let copyright: string = `${new Date().getFullYear()} Airis. Все права защищены.`;
 	export let tone: 'light' | 'dark' = 'light';
 </script>
 
 <div
 	class:footer-dark={tone === 'dark'}
-	class="footer-links mt-16 pt-8 border-t border-gray-200/70 text-gray-500"
+	class="footer-links airis-public-footer-links mt-16 pt-8 border-t"
 >
 	<div class="flex flex-col gap-6 md:flex-row md:items-center md:justify-between">
 		<div class="flex flex-wrap gap-4 text-sm">
@@ -36,18 +36,3 @@
 		<div>ИНН 667803118920 · ОГРНИП 320665800036109</div>
 	</div>
 </div>
-
-<style>
-	.footer-dark {
-		border-color: rgb(255 255 255 / 0.12);
-		color: #a9a2c4;
-	}
-
-	.footer-dark a:hover {
-		color: #ffffff;
-	}
-
-	.footer-dark .font-semibold {
-		color: #d8d2ec;
-	}
-</style>

--- a/src/lib/components/landing/NavHeader.svelte
+++ b/src/lib/components/landing/NavHeader.svelte
@@ -79,30 +79,22 @@
 </a>
 
 <nav
-	class="sticky top-0 z-50 border-b backdrop-blur-md {darkSurface
-		? 'border-white/10 bg-[#1e1647]/95 text-white'
-		: 'border-gray-200/70 bg-white/80'}"
+	class="airis-public-nav {darkSurface ? 'airis-public-nav--dark' : ''}"
 >
 	<div class="container mx-auto px-4">
 		<div class="flex items-center justify-between h-16">
 			<!-- Logo -->
 			<a
 				href="/welcome"
-				class="flex items-center gap-2 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-offset-2 rounded-xl {darkSurface
-					? 'focus-visible:ring-[#ad93fc]'
-					: 'focus-visible:ring-black/60'}"
+				class="airis-public-logo flex items-center gap-2 rounded-xl focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-offset-2 focus-visible:ring-[#ad93fc]"
 			>
 				<div
-					class="w-9 h-9 bg-white rounded-lg border {darkSurface
-						? 'border-white/20'
-						: 'border-gray-200 shadow-sm'} flex items-center justify-center"
+					class="airis-public-logo__mark w-9 h-9 rounded-lg flex items-center justify-center"
 				>
 					<img src="{WEBUI_BASE_URL}/static/favicon.svg" class="w-7 h-7" alt="" draggable="false" />
 				</div>
 				<span
-					class="font-semibold text-lg tracking-tight {darkSurface
-						? 'bg-gradient-to-r from-white via-[#c8b6ff] to-[#8f58ff] bg-clip-text text-transparent'
-						: 'text-gray-900'}">Airis</span
+					class="font-semibold text-lg tracking-tight">Airis</span
 				>
 			</a>
 
@@ -112,13 +104,7 @@
 					<a
 						href={link.href}
 						aria-current={isActive(link.href) ? 'page' : undefined}
-						class="text-sm font-medium transition-colors border-b-2 border-transparent pb-1 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-offset-2 rounded-md {darkSurface
-							? isActive(link.href)
-								? 'text-white border-[#ad93fc] focus-visible:ring-[#ad93fc]'
-								: 'text-[#d8d2ec] hover:text-white focus-visible:ring-[#ad93fc]'
-							: isActive(link.href)
-								? 'text-gray-900 border-gray-900 focus-visible:ring-black/60'
-								: 'text-gray-500 hover:text-gray-900 focus-visible:ring-black/60'}"
+						class="airis-public-nav__link text-sm font-medium border-b-2 border-transparent pb-1 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-[#ad93fc] rounded-md"
 					>
 						{link.label}
 					</a>
@@ -129,18 +115,14 @@
 			<div class="hidden md:flex items-center gap-4">
 				<a
 					href="/auth"
-					class="text-sm font-medium transition-colors focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-offset-2 rounded-lg px-2 py-1 {darkSurface
-						? 'text-[#d8d2ec] hover:text-white focus-visible:ring-[#ad93fc]'
-						: 'text-gray-600 hover:text-gray-900 focus-visible:ring-black/60'}"
+					class="airis-public-nav__login text-sm font-medium focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-[#ad93fc] rounded-lg px-2 py-1"
 					on:click={handleLoginClick}
 				>
 					Войти
 				</a>
 				<a
 					href="/signup"
-					class="inline-flex items-center justify-center h-10 px-5 text-white text-sm font-semibold rounded-xl transition-colors focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-offset-2 {darkSurface
-						? 'bg-[#7132f2] hover:bg-[#6427e8] focus-visible:ring-[#ad93fc]'
-						: 'bg-black hover:bg-gray-900 focus-visible:ring-black/60'}"
+					class="airis-public-btn-primary inline-flex items-center justify-center h-10 px-5 text-sm font-semibold rounded-xl focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-[#ad93fc]"
 					on:click={handleHeaderCta}
 				>
 					Начать бесплатно
@@ -151,26 +133,20 @@
 			<div class="flex md:hidden items-center gap-2">
 				<a
 					href="/auth"
-					class="inline-flex min-h-11 items-center px-1 text-sm font-semibold {darkSurface
-						? 'text-[#d8d2ec] focus-visible:ring-[#ad93fc]'
-						: 'text-gray-600 focus-visible:ring-black/60'} focus-visible:outline-none focus-visible:ring-2"
+					class="airis-public-nav__login inline-flex min-h-11 items-center px-1 text-sm font-semibold focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-[#ad93fc]"
 					on:click={handleLoginClick}
 				>
 					Войти
 				</a>
 				<a
 					href="/signup"
-					class="inline-flex items-center justify-center h-11 px-4 text-white text-sm font-semibold rounded-xl focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-offset-2 {darkSurface
-						? 'bg-[#7132f2] focus-visible:ring-[#ad93fc]'
-						: 'bg-black focus-visible:ring-black/60'}"
+					class="airis-public-btn-primary inline-flex items-center justify-center h-11 px-4 text-sm font-semibold rounded-xl focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-[#ad93fc]"
 					on:click={handleHeaderCta}
 				>
 					{isWelcome() ? 'Начать' : 'Начать бесплатно'}
 				</a>
 				<button
-					class="p-2 {darkSurface
-						? 'text-[#d8d2ec] hover:text-white focus-visible:ring-[#ad93fc]'
-						: 'text-gray-600 hover:text-gray-900 focus-visible:ring-black/60'} focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-offset-2 rounded-lg"
+					class="airis-public-nav__login p-2 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-[#ad93fc] rounded-lg"
 					on:click={() => (mobileMenuOpen = !mobileMenuOpen)}
 					aria-label={mobileMenuOpen ? 'Закрыть меню' : 'Открыть меню'}
 					aria-expanded={mobileMenuOpen}
@@ -202,36 +178,26 @@
 		<!-- Mobile Menu -->
 		{#if mobileMenuOpen}
 			<div
-				class="md:hidden py-4 border-t {darkSurface ? 'border-white/10' : 'border-gray-200/70'}"
+				class="airis-public-nav__mobile md:hidden py-4 border-t"
 				id="mobile-nav"
 			>
 				<div class="flex flex-col gap-4">
 					{#each navLinks as link}
 						<a
 							href={link.href}
-							aria-current={isActive(link.href) ? 'page' : undefined}
-							class="text-sm font-medium px-2 py-2 focus-visible:outline-none focus-visible:ring-2 rounded-md {darkSurface
-								? isActive(link.href)
-									? 'text-white focus-visible:ring-[#ad93fc]'
-									: 'text-[#d8d2ec] focus-visible:ring-[#ad93fc]'
-								: isActive(link.href)
-									? 'text-gray-900'
-									: 'text-gray-600'}"
+						aria-current={isActive(link.href) ? 'page' : undefined}
+							class="airis-public-nav__link text-sm font-medium px-2 py-2 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-[#ad93fc] rounded-md"
 							on:click={() => (mobileMenuOpen = false)}
 						>
 							{link.label}
 						</a>
 					{/each}
 					<div
-						class="flex flex-col gap-2 pt-4 border-t {darkSurface
-							? 'border-white/10'
-							: 'border-gray-200/70'}"
+						class="airis-public-nav__mobile flex flex-col gap-2 pt-4 border-t"
 					>
 						<a
 							href="/auth"
-							class="text-sm font-medium px-2 py-2 focus-visible:outline-none focus-visible:ring-2 rounded-md {darkSurface
-								? 'text-[#d8d2ec] focus-visible:ring-[#ad93fc]'
-								: 'text-gray-600 focus-visible:ring-black/60'}"
+							class="airis-public-nav__login text-sm font-medium px-2 py-2 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-[#ad93fc] rounded-md"
 							on:click={handleLoginClick}
 						>
 							Войти

--- a/src/lib/components/landing/PublicPageLayout.svelte
+++ b/src/lib/components/landing/PublicPageLayout.svelte
@@ -11,19 +11,19 @@
 	export let heroEyebrow: string = '';
 	export let heroImage: string = '';
 	export let heroImageAlt: string = '';
-	export let tone: 'light' | 'dark' = 'light';
+	export let tone: 'light' | 'dark' = 'dark';
 </script>
 
 <svelte:head>
 	{#if title}
-		<title>{title} - AIris</title>
+		<title>{title} - Airis</title>
 	{/if}
 	{#if description}
 		<meta name="description" content={description} />
 	{/if}
 </svelte:head>
 
-<div class="public-page min-h-screen text-gray-900 flex flex-col font-primary" data-tone={tone}>
+<div class="public-page airis-public-page min-h-screen flex flex-col" data-tone={tone}>
 	<NavHeader currentPath={$page.url.pathname} {tone} />
 
 	{#if showHero}
@@ -67,9 +67,9 @@
 		<slot />
 	</main>
 
-	<footer class="public-page__footer border-t border-violet-200/70 py-8">
+	<footer class="public-page__footer airis-public-footer border-t py-8">
 		<div class="container mx-auto px-4">
-			<FooterLinks copyright={`${new Date().getFullYear()} AIris. Все права защищены.`} />
+			<FooterLinks tone={tone} copyright={`${new Date().getFullYear()} Airis. Все права защищены.`} />
 		</div>
 	</footer>
 </div>
@@ -79,15 +79,8 @@
 		overflow-x: hidden;
 	}
 
-	.public-page {
-		background:
-			radial-gradient(900px 420px at 8% 0%, rgb(113 50 242 / 0.12), transparent 70%),
-			radial-gradient(760px 420px at 100% 12%, rgb(173 147 252 / 0.14), transparent 72%),
-			linear-gradient(180deg, #f8f7ff 0%, #ffffff 58%, #f7f5ff 100%);
-	}
-
 	.public-page__footer {
-		background: rgb(255 255 255 / 0.76);
+		background: transparent;
 	}
 
 	:global(.public-page section[id]) {

--- a/src/lib/components/landing/publicTheme.css
+++ b/src/lib/components/landing/publicTheme.css
@@ -1,0 +1,233 @@
+/* Shared public Airis visual language. Keep this scope outside the app shell. */
+.airis-public-page {
+	--airis-bg: #17112f;
+	--airis-bg-strong: #211545;
+	--airis-surface: #211a3d;
+	--airis-surface-soft: #1d1637;
+	--airis-ink: #f8f6ff;
+	--airis-muted: #c4bddc;
+	--airis-muted-strong: #e0daf3;
+	--airis-line: rgb(255 255 255 / 0.13);
+	--airis-deep: #211545;
+	--airis-accent: #7132f2;
+	--airis-accent-hover: #6427e8;
+	--airis-accent-soft: #eee7ff;
+	background:
+		radial-gradient(720px 360px at 8% 0%, rgb(113 50 242 / 0.24), transparent 72%),
+		radial-gradient(680px 360px at 100% 10%, rgb(173 147 252 / 0.12), transparent 72%),
+		linear-gradient(180deg, var(--airis-bg) 0%, #1b1437 52%, var(--airis-bg) 100%);
+	color: var(--airis-ink);
+	font-family: 'Inter', 'Noto Sans', system-ui, sans-serif;
+}
+
+.airis-public-page main {
+	position: relative;
+}
+
+.airis-public-page .container,
+.airis-public-page [class*='max-w-[1200px]'] {
+	max-width: 1180px;
+}
+
+.airis-public-page .text-gray-900 {
+	color: var(--airis-ink) !important;
+}
+
+.airis-public-page .text-gray-700 {
+	color: var(--airis-muted-strong) !important;
+}
+
+.airis-public-page .text-gray-600,
+.airis-public-page .text-gray-500 {
+	color: var(--airis-muted) !important;
+}
+
+.airis-public-page .text-gray-400 {
+	color: #a9a2c4 !important;
+}
+
+.airis-public-page .border-gray-200,
+.airis-public-page .border-gray-200\/70,
+.airis-public-page .border-gray-300 {
+	border-color: var(--airis-line) !important;
+}
+
+.airis-public-page .bg-white,
+.airis-public-page .bg-white\/80,
+.airis-public-page .bg-white\/90 {
+	background-color: rgb(33 26 61 / 0.94) !important;
+}
+
+.airis-public-page .bg-gray-50,
+.airis-public-page .bg-gray-100,
+.airis-public-page [class*='bg-[#f7f7f8]'],
+.airis-public-page section[class*='bg-[radial-gradient'] {
+	background: var(--airis-surface-soft) !important;
+}
+
+.airis-public-page .bg-gray-900 {
+	background-color: var(--airis-deep) !important;
+}
+
+/* Feature and pricing sections have their own local styles; keep their surfaces on the same canvas. */
+.airis-public-page .features-section,
+.airis-public-page .features-section--soft {
+	background: transparent !important;
+}
+
+.airis-public-page .features-section--cta {
+	background: var(--airis-deep) !important;
+}
+
+.airis-public-page a.bg-black,
+.airis-public-page button.bg-black {
+	background-color: var(--airis-accent) !important;
+}
+
+.airis-public-page a.bg-black:hover,
+.airis-public-page button.bg-black:hover {
+	background-color: var(--airis-accent-hover) !important;
+}
+
+.airis-public-page .text-red-600 {
+	color: #ff9eb7 !important;
+}
+
+.airis-public-page [class*='text-[#5d24d6]'],
+.airis-public-page [class*='text-[#7132f2]'] {
+	color: #c4b5fd !important;
+}
+
+.airis-public-page a:not(.airis-public-btn-primary):not(.airis-public-btn-secondary) {
+	text-underline-offset: 3px;
+}
+
+.airis-public-page .airis-public-btn-primary,
+.airis-public-btn-primary {
+	background: var(--airis-accent);
+	color: #ffffff;
+	transition: background-color 160ms ease, transform 160ms ease, box-shadow 160ms ease;
+}
+
+.airis-public-page .airis-public-btn-primary:hover,
+.airis-public-btn-primary:hover {
+	background: var(--airis-accent-hover);
+	box-shadow: 0 12px 30px rgb(89 44 180 / 0.2);
+	transform: translateY(-1px);
+}
+
+.airis-public-page .airis-public-btn-secondary,
+.airis-public-btn-secondary {
+	border: 1px solid var(--airis-line);
+	background: rgb(255 255 255 / 0.06);
+	color: #f8f6ff;
+}
+
+.airis-public-page .airis-public-btn-secondary:hover,
+.airis-public-btn-secondary:hover {
+	border-color: #c7b3ff;
+	background: var(--airis-accent-soft);
+}
+
+.airis-public-nav {
+	position: sticky;
+	top: 0;
+	z-index: 50;
+	border-bottom: 1px solid var(--airis-line);
+	background: rgb(30 22 71 / 0.92);
+	color: #ffffff;
+	backdrop-filter: blur(18px);
+}
+
+.airis-public-nav--dark {
+	border-color: rgb(255 255 255 / 0.1);
+	background: rgb(30 22 71 / 0.92);
+	color: #ffffff;
+}
+
+.airis-public-logo {
+	color: #ffffff;
+}
+
+.airis-public-nav--dark .airis-public-logo {
+	color: #ffffff;
+}
+
+.airis-public-logo__mark {
+	border: 1px solid var(--airis-line);
+	background: #ffffff;
+}
+
+.airis-public-nav__link,
+.airis-public-nav__login {
+	color: #d8d2ec;
+	transition: color 160ms ease;
+}
+
+.airis-public-nav__link:hover,
+.airis-public-nav__login:hover,
+.airis-public-nav__link[aria-current='page'] {
+	color: #ffffff;
+}
+
+.airis-public-nav__link[aria-current='page'] {
+	border-color: var(--airis-accent);
+}
+
+.airis-public-nav--dark .airis-public-nav__link,
+.airis-public-nav--dark .airis-public-nav__login {
+	color: #d8d2ec;
+}
+
+.airis-public-nav--dark .airis-public-nav__link:hover,
+.airis-public-nav--dark .airis-public-nav__login:hover,
+.airis-public-nav--dark .airis-public-nav__link[aria-current='page'] {
+	color: #ffffff;
+}
+
+.airis-public-nav__mobile {
+	border-color: var(--airis-line);
+}
+
+.airis-public-nav--dark .airis-public-nav__mobile {
+	border-color: rgb(255 255 255 / 0.1);
+}
+
+.airis-public-footer {
+	border-color: var(--airis-line);
+	background: rgb(30 22 71 / 0.66);
+}
+
+.airis-public-footer-links {
+	border-color: var(--airis-line);
+	color: var(--airis-muted);
+}
+
+.airis-public-footer-links a:hover {
+	color: #ffffff;
+}
+
+.airis-public-footer-links .font-semibold {
+	color: #d8d2ec;
+}
+
+.airis-public-footer-links.footer-dark {
+	border-color: rgb(255 255 255 / 0.12);
+	color: #a9a2c4;
+}
+
+.airis-public-footer-links.footer-dark a:hover {
+	color: #ffffff;
+}
+
+.airis-public-footer-links.footer-dark .font-semibold {
+	color: #d8d2ec;
+}
+
+@media (prefers-reduced-motion: reduce) {
+	.airis-public-page *,
+	.airis-public-nav * {
+		transition-duration: 0.01ms !important;
+		animation-duration: 0.01ms !important;
+	}
+}


### PR DESCRIPTION
## What changed

- Added one scoped Airis public design-token layer with deep-violet surfaces, lavender accent, readable muted text, shared focus states, and reduced-motion handling.
- Switched public navigation, mobile menu, primary CTA, footer, and metadata to the shared shell.
- Applied the shell to all existing marketing and legal routes without changing product copy, API-backed pricing/model data, redirects, or legal text.
- Preserved real Airis product screenshots and intentional dark UI contrast.

## Why

`/welcome` used the current Airis visual system while the rest of the public site still rendered as unrelated gray/black pages. Centralizing the shell removes that visual break and fixes the footer tone propagation bug.

## Validation

- `npm run test:frontend -- --run src/lib/components/landing` (7 passed)
- `npx eslint src/lib/components/landing/NavHeader.svelte src/lib/components/landing/FooterLinks.svelte src/lib/components/landing/PublicPageLayout.svelte`
- `NODE_OPTIONS=--max-old-space-size=8192 npm run build:vite`
- In-app browser smoke test for `/welcome`, `/features`, `/pricing`, `/about`, `/contact`, `/documents`, `/terms`, `/privacy`, and all nested document routes
- `npm run check` still reports pre-existing repository-wide diagnostics; no diagnostics in changed shell files

## Risk

Public CSS is scoped to `.airis-public-page` and shared public shell classes; authenticated app/admin screens are not affected.