### PR TITLE
fix(billing): Make low-balance top-up action explicit

### DIFF
--- a/meta/memory_bank/branch_updates/2026-08-07-codex-fix-wallet-topup-clarity.md
+++ b/meta/memory_bank/branch_updates/2026-08-07-codex-fix-wallet-topup-clarity.md
@@ -1,7 +1,9 @@
-- [ ] **[BUGFIX][BILLING][UX]** Make low-balance top-up action obvious and keep fallback pricing truthful
+- [x] **[BUGFIX][BILLING][UX]** Make low-balance top-up action obvious and keep fallback pricing truthful
   - Spec: `meta/memory_bank/specs/work_items/2026-08-07__feature__billing-topup-recovery-clarity.md`
   - Owner: Codex
   - Branch: `codex/fix-wallet-topup-clarity`
   - Started: 2026-08-07
   - Summary: Preselect the first supported package for low-balance users, keep payment explicit and free usage visible, and hide custom input when pricing discovery fails.
-  - Tests: Focused billing/modal tests 14 passed; full frontend Vitest 30 files / 116 tests passed; targeted ESLint passed. Vite build reached chunk rendering but hit the local Node heap limit.
+  - Done: 2026-08-07
+  - Tests: Focused billing/modal tests 14 passed; full frontend Vitest 30 files / 116 tests passed; targeted ESLint passed; Vite build passed with `NODE_OPTIONS=--max-old-space-size=8192`; `git diff --check` passed.
+  - Production: `git-1a3e852` deployed with guarded backup, migration gate, health gate, and rollback image. Wallet CTA and blocked paid-model recovery verified in the authenticated in-app browser; console errors: none.

--- a/meta/memory_bank/branch_updates/2026-08-07-codex-fix-wallet-topup-clarity.md
+++ b/meta/memory_bank/branch_updates/2026-08-07-codex-fix-wallet-topup-clarity.md
@@ -1,0 +1,7 @@
+- [ ] **[BUGFIX][BILLING][UX]** Make low-balance top-up action obvious and keep fallback pricing truthful
+  - Spec: `meta/memory_bank/specs/work_items/2026-08-07__feature__billing-topup-recovery-clarity.md`
+  - Owner: Codex
+  - Branch: `codex/fix-wallet-topup-clarity`
+  - Started: 2026-08-07
+  - Summary: Preselect the first supported package for low-balance users, keep payment explicit and free usage visible, and hide custom input when pricing discovery fails.
+  - Tests: Focused billing/modal tests 14 passed; full frontend Vitest 30 files / 116 tests passed; targeted ESLint passed. Vite build reached chunk rendering but hit the local Node heap limit.

--- a/meta/memory_bank/specs/work_items/2026-08-07__feature__billing-topup-recovery-clarity.md
+++ b/meta/memory_bank/specs/work_items/2026-08-07__feature__billing-topup-recovery-clarity.md
@@ -5,20 +5,22 @@
 - Type: feature
 - Status: in_progress
 - Owner: Codex
-- Branch: `codex/feature/billing-balance-history-simplify`
+- Branch: `codex/fix-wallet-topup-clarity`
 - Created: 2026-08-07
 - Updated: 2026-08-07
 - SDD Spec: `meta/sdd/specs/active/billing-topup-recovery-clarity-2026-08-07-001.json`
 
 ## Context
 
-The wallet is functional, but the payment path is easy to miss: package choices look like small secondary pills, the payment CTA is disabled until selection, and the insufficient-funds dialog does not show the shortfall or what happens next. The user should understand the problem and reach a safe payment choice in one clear step without automatic charging or repeated prompts.
+The wallet is functional, but the payment path is easy to miss: package choices look like small secondary pills, the payment CTA is disabled until selection, and the insufficient-funds dialog does not show the shortfall or what happens next. The user should understand the problem and reach a safe payment choice in one clear step without automatic charging or repeated prompts. A pricing-config outage must not expose a custom amount that the server will reject.
 
 ## Goal / acceptance criteria
 
 - When a paid model is blocked, the dialog states that funds are insufficient, shows available/required/shortfall amounts, and gives one clear wallet CTA.
 - The wallet CTA preserves the originating chat and passes the required amount so the smallest configured package covering the request is selected automatically.
 - The wallet page uses explicit “Пополнить баланс” copy, accessible package hit targets, and a clear payment action after selection.
+- A low-balance wallet preselects the first configured package while keeping free usage visible as a separate alternative; users still confirm payment explicitly.
+- A pricing-config failure keeps the UI on server-supported preset packages and hides unsupported custom input.
 - Returning from payment remains the existing user-controlled path; no automatic purchase or automatic message retry is introduced.
 - Daily-cap and max-reply-cost blocks retain their existing settings route and copy.
 
@@ -38,7 +40,7 @@ The wallet is functional, but the payment path is easy to miss: package choices 
 
 ## Verification
 
-- Focused Vitest coverage for contextual package selection and billing CTA links.
+- Focused Vitest coverage for contextual package selection, low-balance default selection, pricing fallback, and billing CTA links.
 - Full frontend Vitest regression.
 - In-app browser: zero-balance paid-model request opens the modal; wallet CTA opens the wallet with the originating chat preserved and a recommended package selected; console has no errors.
 
@@ -46,7 +48,7 @@ The wallet is functional, but the payment path is easy to miss: package choices 
 
 - Completed: focused billing/header/websocket tests (19 tests) and full frontend regression (29 files, 109 tests).
 - Completed: authenticated production browser confirmed the zero-balance paid-model request opens the billing modal with no console errors on the currently deployed build.
-- Pending: deploy this commit and repeat the production browser path; Docker Hub rejected the image push and SSH/health access to production timed out during rollout.
+- Pending: deploy this branch and repeat the production browser path.
 
 ## Upstream impact
 

--- a/meta/memory_bank/specs/work_items/2026-08-07__feature__billing-topup-recovery-clarity.md
+++ b/meta/memory_bank/specs/work_items/2026-08-07__feature__billing-topup-recovery-clarity.md
@@ -3,12 +3,12 @@
 ## Meta
 
 - Type: feature
-- Status: in_progress
+- Status: done
 - Owner: Codex
 - Branch: `codex/fix-wallet-topup-clarity`
 - Created: 2026-08-07
 - Updated: 2026-08-07
-- SDD Spec: `meta/sdd/specs/active/billing-topup-recovery-clarity-2026-08-07-001.json`
+- SDD Spec: `meta/sdd/specs/completed/billing-topup-recovery-clarity-2026-08-07-001.json`
 
 ## Context
 
@@ -46,9 +46,10 @@ The wallet is functional, but the payment path is easy to miss: package choices 
 
 ## Current verification status
 
-- Completed: focused billing/header/websocket tests (19 tests) and full frontend regression (29 files, 109 tests).
-- Completed: authenticated production browser confirmed the zero-balance paid-model request opens the billing modal with no console errors on the currently deployed build.
-- Pending: deploy this branch and repeat the production browser path.
+- Completed: focused billing/modal tests (14 tests) and full frontend regression (30 files, 116 tests).
+- Completed: targeted ESLint, Vite build with an 8 GB Node heap, and `git diff --check`.
+- Completed: `git-1a3e852` deployed with guarded backup, migration gate, health gate, and rollback image retained; production `/health` returned `{"status":true}`.
+- Completed: authenticated in-app browser verified the low-balance wallet preselects 500 ₽ and enables `Оплатить 500 ₽`; a paid Qwen 3.7 Plus request at 0 ₽ opens the insufficient-funds modal, preserves safe `return_to`, and selects the contextual package. Production console errors: none.
 
 ## Upstream impact
 

--- a/meta/sdd/specs/completed/billing-topup-recovery-clarity-2026-08-07-001.json
+++ b/meta/sdd/specs/completed/billing-topup-recovery-clarity-2026-08-07-001.json
@@ -2,7 +2,7 @@
   "spec_id": "billing-topup-recovery-clarity-2026-08-07-001",
   "title": "billing topup recovery clarity",
   "generated": "2026-08-07T16:47:13.153781Z",
-  "last_updated": "2026-08-07T17:22:04.324906Z",
+  "last_updated": "2026-08-07T20:25:22.409142Z",
   "metadata": {
     "template": "medium",
     "complexity": "medium",
@@ -11,15 +11,16 @@
     "security_sensitive": false,
     "default_category": "implementation",
     "work_item_spec": "meta/memory_bank/specs/work_items/2026-08-07__feature__billing-topup-recovery-clarity.md",
-    "status": "active",
+    "status": "completed",
     "activated_date": "2026-08-07T16:47:18.055211Z",
-    "progress_percentage": 66
+    "progress_percentage": 100,
+    "completed_date": "2026-08-07T20:25:22.408756Z"
   },
   "hierarchy": {
     "spec-root": {
       "type": "spec",
       "title": "billing topup recovery clarity",
-      "status": "in_progress",
+      "status": "completed",
       "parent": null,
       "children": [
         "phase-1",
@@ -27,7 +28,7 @@
         "phase-3"
       ],
       "total_tasks": 3,
-      "completed_tasks": 2,
+      "completed_tasks": 3,
       "metadata": {}
     },
     "phase-1": {
@@ -65,14 +66,18 @@
     "phase-3": {
       "type": "phase",
       "title": "Phase 3: [To Be Defined]",
-      "status": "pending",
+      "status": "completed",
       "parent": "spec-root",
       "children": [
         "task-3-1"
       ],
       "total_tasks": 1,
-      "completed_tasks": 0,
-      "metadata": {}
+      "completed_tasks": 1,
+      "metadata": {
+        "needs_journaling": false,
+        "completed_at": "2026-08-07T20:25:17.480487Z",
+        "journaled_at": "2026-08-07T20:25:17.484652Z"
+      }
     },
     "task-1-1": {
       "type": "task",
@@ -121,7 +126,7 @@
     "task-3-1": {
       "type": "verify",
       "title": "Run depletion and top-up regression",
-      "status": "pending",
+      "status": "completed",
       "parent": "phase-3",
       "children": [],
       "dependencies": {
@@ -130,11 +135,15 @@
         "depends": []
       },
       "total_tasks": 1,
-      "completed_tasks": 0,
+      "completed_tasks": 1,
       "metadata": {
         "estimated_hours": 3.0,
         "started_at": "2026-08-07T17:22:04.324693Z",
-        "status_note": "Frontend regression passed (29 files, 109 tests); production browser verification is pending because Docker Hub push was denied and SSH/health access timed out."
+        "status_note": "Frontend regression passed: 30 files, 116 tests. Production deployed as git-1a3e852; health returned status true. In-app browser verified low-balance wallet preselects 500 \u20bd and enables \u041e\u043f\u043b\u0430\u0442\u0438\u0442\u044c 500 \u20bd, paid Qwen 3.7 Plus at 0 \u20bd opens \u041d\u0435\u0434\u043e\u0441\u0442\u0430\u0442\u043e\u0447\u043d\u043e \u0441\u0440\u0435\u0434\u0441\u0442\u0432 modal with available/required/shortfall, safe return_to and contextual package selection; production console errors: none.",
+        "completed_at": "2026-08-07T20:25:17.480265Z",
+        "needs_journaling": false,
+        "actual_hours": 3.054,
+        "journaled_at": "2026-08-07T20:25:17.482771Z"
       },
       "description": "Test frontend state transitions and verify the production blocked-chat flow in the in-app browser."
     }
@@ -175,6 +184,24 @@
       "content": "All child tasks in phase phase-2 have been completed.",
       "metadata": {},
       "task_id": "phase-2"
+    },
+    {
+      "timestamp": "2026-08-07T20:25:17.482760Z",
+      "entry_type": "status_change",
+      "title": "Production top-up recovery verified",
+      "author": "Codex",
+      "content": "Guarded deploy backup, migration gate, health gate and browser regression all passed.",
+      "metadata": {},
+      "task_id": "task-3-1"
+    },
+    {
+      "timestamp": "2026-08-07T20:25:17.484645Z",
+      "entry_type": "status_change",
+      "title": "Phase Completed: Phase 3: [To Be Defined]",
+      "author": "Codex",
+      "content": "All child tasks in phase phase-3 have been completed.",
+      "metadata": {},
+      "task_id": "phase-3"
     }
   ]
 }

--- a/src/lib/components/airis/BillingBlockedModal.test.ts
+++ b/src/lib/components/airis/BillingBlockedModal.test.ts
@@ -1,0 +1,124 @@
+// @vitest-environment jsdom
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { mount, unmount } from 'svelte';
+
+import BillingBlockedModal from './BillingBlockedModal.svelte';
+import type { BillingBlockedDetail } from '$lib/utils/airis/billing_block';
+
+const mocks = vi.hoisted(() => ({
+	gotoMock: vi.fn(),
+	i18nStore: {
+		locale: 'en',
+		t: (key: string) => key,
+		subscribe: (run: (value: { locale: string; t: (key: string) => string }) => void) => {
+			run(mocks.i18nStore);
+			return () => undefined;
+		}
+	}
+}));
+
+vi.mock('$app/navigation', () => ({ goto: mocks.gotoMock }));
+vi.mock('focus-trap', () => ({
+	createFocusTrap: () => ({
+		activate: vi.fn(),
+		deactivate: vi.fn(),
+		pause: vi.fn(),
+		unpause: vi.fn()
+	})
+}));
+
+const createContext = (): Map<string, unknown> => new Map([['i18n', mocks.i18nStore]]);
+
+const insufficientFunds = (
+	overrides: Partial<Extract<BillingBlockedDetail, { error: 'insufficient_funds' }>> = {}
+): BillingBlockedDetail => ({
+	error: 'insufficient_funds',
+	available_kopeks: 0,
+	required_kopeks: 2500,
+	currency: 'RUB',
+	auto_topup_status: null,
+	auto_topup_payment_id: null,
+	message: null,
+	...overrides
+});
+
+describe('BillingBlockedModal', () => {
+	let mounted: Record<string, unknown> | null = null;
+
+	beforeEach(() => {
+		mocks.gotoMock.mockReset();
+		document.body.innerHTML = '';
+	});
+
+	afterEach(async () => {
+		if (mounted) {
+			await unmount(mounted);
+		}
+		mounted = null;
+		document.body.innerHTML = '';
+	});
+
+	const renderModal = (detail: BillingBlockedDetail, returnTo: string | null = '/c/123') => {
+		const target = document.createElement('div');
+		document.body.appendChild(target);
+		mounted = mount(BillingBlockedModal, {
+			target,
+			context: createContext(),
+			props: { open: true, detail, returnTo }
+		});
+		return document.body;
+	};
+
+	it('shows the shortfall and routes a blocked reply to a contextual top-up', async () => {
+		const root = renderModal(insufficientFunds({ available_kopeks: 500, required_kopeks: 2500 }));
+		await Promise.resolve();
+
+		expect(root.querySelector('[role="dialog"][aria-modal="true"]')).toBeTruthy();
+		expect(root.querySelector('button[aria-label="Close"]')).toBeTruthy();
+		expect(root.querySelector('[data-testid="billing-blocked-modal"]')?.textContent).toContain(
+			'Shortfall'
+		);
+		expect(root.querySelector('[data-testid="billing-blocked-shortfall"]')?.textContent).toContain(
+			'20'
+		);
+
+		const topUp = [...root.querySelectorAll('button')].find((button) =>
+			button.textContent?.includes('Top up balance')
+		) as HTMLButtonElement | undefined;
+		expect(topUp).toBeTruthy();
+		topUp?.click();
+		await Promise.resolve();
+
+		expect(mocks.gotoMock).toHaveBeenCalledWith(
+		'/billing/balance?src=chat_blocked&return_to=%2Fc%2F123&focus=topup&required_kopeks=2500'
+		);
+	});
+
+	it('drops an untrusted return path from the payment CTA', async () => {
+		const root = renderModal(insufficientFunds(), 'https://evil.example/steal');
+		await Promise.resolve();
+
+		const topUp = [...root.querySelectorAll('button')].find((button) =>
+			button.textContent?.includes('Top up balance')
+		) as HTMLButtonElement | undefined;
+		topUp?.click();
+		await Promise.resolve();
+
+		expect(mocks.gotoMock).toHaveBeenCalledWith(
+		'/billing/balance?src=chat_blocked&focus=topup&required_kopeks=2500'
+		);
+		expect(mocks.gotoMock.mock.calls[0]?.[0]).not.toContain('evil.example');
+	});
+
+	it('keeps the payment CTA visible while an auto-top-up payment is processing', async () => {
+		const root = renderModal(insufficientFunds({ auto_topup_status: 'pending' }));
+		await Promise.resolve();
+
+		expect(root.textContent).toContain('Top-up is processing');
+		expect(
+		[...root.querySelectorAll('button')].some((button) =>
+			button.textContent?.includes('Top up balance')
+		)
+		).toBe(true);
+	});
+});

--- a/src/lib/components/airis/HeaderBillingAccess.svelte
+++ b/src/lib/components/airis/HeaderBillingAccess.svelte
@@ -162,6 +162,7 @@
 			class="flex h-full shrink-0 items-center justify-center px-2 text-gray-700 transition hover:bg-gray-100/80 hover:text-gray-900 dark:text-gray-300 dark:hover:bg-gray-800/80 dark:hover:text-gray-50"
 			data-testid="header-billing-topup"
 			aria-label={$i18n.t('Top up balance')}
+			title={$i18n.t('Top up balance')}
 		>
 			<Plus className="size-3.5" strokeWidth="2.2" />
 			<span class="hidden pl-1 text-xs font-medium sm:inline">{$i18n.t('Top up balance')}</span>

--- a/src/lib/components/billing/WalletTopupSection.svelte
+++ b/src/lib/components/billing/WalletTopupSection.svelte
@@ -6,6 +6,7 @@
 	export let currency: string;
 	export let defaultPackages: number[] = [];
 	export let allowCustom = true;
+	export let autoSelectFirst = false;
 	export let highlightedPackageKopeks: number | null = null;
 	export let highlightedPackageLabel: string | null = null;
 	export let creatingTopupAmount: number | null = null;
@@ -18,7 +19,8 @@
 		try {
 			return new Intl.NumberFormat($i18n.locale, {
 				style: 'currency',
-				currency: currencyCode
+				currency: currencyCode,
+				maximumFractionDigits: Number.isInteger(amount) ? 0 : 2
 			}).format(amount);
 		} catch (error) {
 			console.warn('Invalid currency code:', currencyCode, error);
@@ -42,10 +44,13 @@
 
 	$: if (
 		!userSelected &&
-		highlightedPackageKopeks !== null &&
-		defaultPackages.includes(highlightedPackageKopeks)
+		selectedPackageKopeks === null
 	) {
-		selectedPackageKopeks = highlightedPackageKopeks;
+		const suggestedPackage =
+			highlightedPackageKopeks ?? (autoSelectFirst ? defaultPackages[0] ?? null : null);
+		if (suggestedPackage !== null && defaultPackages.includes(suggestedPackage)) {
+			selectedPackageKopeks = suggestedPackage;
+		}
 	}
 
 	const handleSelectPackage = (amount: number): void => {

--- a/src/routes/(app)/billing/balance/+page.svelte
+++ b/src/routes/(app)/billing/balance/+page.svelte
@@ -159,7 +159,8 @@
 			console.warn('Failed to load public pricing config:', error);
 		}
 		topupPackages = DEFAULT_TOPUP_PACKAGES_KOPEKS;
-		allowCustomTopup = true;
+		// Keep the UI aligned with the server allowlist when pricing discovery is unavailable.
+		allowCustomTopup = false;
 	};
 
 	const readLastTopupKopeks = (): number | null => {
@@ -913,6 +914,7 @@
 						<button
 							type="button"
 							data-testid="wallet-hero-topup"
+							aria-controls="topup-section"
 							on:click={scrollToTopup}
 							class="px-3 py-1.5 rounded-xl bg-black text-white dark:bg-white dark:text-black transition text-sm font-medium {isLowBalance
 								? 'ring-2 ring-amber-500/40'
@@ -984,6 +986,7 @@
 					currency={balance.currency}
 					defaultPackages={topupPackages}
 					allowCustom={allowCustomTopup}
+					autoSelectFirst={isLowBalance}
 					{highlightedPackageKopeks}
 					{highlightedPackageLabel}
 					{creatingTopupAmount}

--- a/src/routes/(app)/billing/balance/billing-balance.test.ts
+++ b/src/routes/(app)/billing/balance/billing-balance.test.ts
@@ -261,6 +261,22 @@ describe('Billing balance page', () => {
 		expect(proceed?.disabled).toBe(false);
 	});
 
+	it('preselects the first package for a low balance without free usage', async () => {
+		mocks.getBalanceMock.mockResolvedValue(createBalance({ balance_topup_kopeks: 0 }));
+		mocks.getPublicPricingConfigMock.mockResolvedValue({ topup_amounts_rub: [500, 1000, 2000] });
+
+		const root = renderPage();
+		await flushPromises();
+		await flushPromises();
+
+		const presets = [...root.querySelectorAll('[data-testid="topup-preset"]')];
+		const proceed = root.querySelector('[data-testid="topup-proceed"]') as HTMLButtonElement | null;
+
+		expect(presets[0]?.getAttribute('aria-pressed')).toBe('true');
+		expect(proceed?.disabled).toBe(false);
+		expect(proceed?.textContent).toContain('Pay');
+	});
+
 	it('hides free-limit hint when free models are unavailable', async () => {
 		mocks.getBalanceMock.mockResolvedValue(createBalance({ balance_topup_kopeks: 5000 }));
 		mocks.getLeadMagnetInfoMock.mockResolvedValue(createLeadMagnetInfo(true));
@@ -292,6 +308,20 @@ describe('Billing balance page', () => {
 		expect(root.textContent).toContain('Wallet is low but free limit is available');
 		expect(root.querySelector('[data-testid="wallet-low-balance-hint-free"]')).toBeTruthy();
 		expect(root.querySelector('[data-testid="wallet-low-balance-hint-topup"]')).toBeNull();
+		const proceed = root.querySelector('[data-testid="topup-proceed"]') as HTMLButtonElement | null;
+		expect(proceed?.disabled).toBe(false);
+	});
+
+	it('keeps custom top-up hidden when pricing discovery fails', async () => {
+		mocks.getBalanceMock.mockResolvedValue(createBalance());
+		mocks.getPublicPricingConfigMock.mockRejectedValue(new Error('pricing unavailable'));
+
+		const root = renderPage();
+		await flushPromises();
+		await flushPromises();
+
+		expect(root.querySelector('input[name="custom_topup"]')).toBeNull();
+		expect(root.textContent).toContain('Custom top-up amounts are unavailable');
 	});
 
 	it('sends normalized return_url for top-up when return_to is valid', async () => {


### PR DESCRIPTION
## Summary

- Preselect the first supported package on low-balance wallets and keep the payment action explicit.
- Render simple whole-ruble amounts and add the missing mobile top-up affordance.
- Hide unsupported custom amounts when public pricing discovery fails.
- Preserve blocked-chat recovery: available/required/shortfall, safe return_to, contextual package selection.

## Verification

- `npm run test:frontend -- --run` — 30 files, 116 tests.
- Targeted ESLint and `git diff --check` passed.
- `NODE_OPTIONS=--max-old-space-size=8192 npm run build:vite` passed.
- Production `git-1a3e852` deployed with guarded backup, migration gate, health gate, and rollback image.
- In-app browser: wallet CTA and zero-balance Qwen 3.7 Plus blocked-reply modal verified; production console errors: none.

## Risk

No backend, pricing, or payment contract changes. No automatic charging or message retry.
