### PR TITLE
test: guard wallet free-limit disclosure

### DIFF
--- a/e2e/billing_wallet_recovery.spec.ts
+++ b/e2e/billing_wallet_recovery.spec.ts
@@ -157,6 +157,36 @@ test.describe('Billing wallet recovery (smoke)', () => {
 		await expect(page.getByTestId('wallet-low-balance-hint-topup')).toHaveCount(0);
 	});
 
+	test('keeps free-limit details collapsed until disclosed', async ({ page }) => {
+		await page.setViewportSize({ width: 390, height: 844 });
+		await page.route('**/api/models**', async (route) => {
+			await route.fulfill({ json: leadMagnetModelsResponse });
+		});
+
+		await page.goto('/billing/balance');
+		await page.waitForResponse('**/api/v1/billing/lead-magnet');
+
+		const leadMagnetSection = page.getByTestId('lead-magnet-section');
+		const limitsButton = leadMagnetSection.getByRole('button', { name: 'Limits', exact: true });
+		await expect(limitsButton).toHaveAttribute('aria-expanded', 'false');
+		await expect(leadMagnetSection.locator('#free-limit-details')).toHaveCount(0);
+		await expect(page.getByTestId('topup-proceed')).toBeVisible();
+
+		const hasHorizontalOverflow = await page.evaluate(
+			() => document.documentElement.scrollWidth > document.documentElement.clientWidth
+		);
+		expect(hasHorizontalOverflow).toBe(false);
+
+		await limitsButton.focus();
+		await limitsButton.press('Enter');
+		await expect(limitsButton).toHaveAttribute('aria-expanded', 'true');
+		await expect(leadMagnetSection.locator('#free-limit-details')).toBeVisible();
+		await expect(leadMagnetSection.getByText('Input', { exact: true })).toBeVisible();
+		await expect(
+			leadMagnetSection.getByRole('button', { name: 'Models included (1)', exact: true })
+		).toBeVisible();
+	});
+
 	test('shows low-balance top-up hint when free models are unavailable and keeps topup wiring', async ({
 		page
 	}) => {

--- a/meta/memory_bank/branch_updates/2026-08-08-codex-billing-wallet-e2e-smoke.md
+++ b/meta/memory_bank/branch_updates/2026-08-08-codex-billing-wallet-e2e-smoke.md
@@ -1,0 +1,10 @@
+### Done
+
+- [x] **[REFACTOR][TEST][BILLING]** Add wallet free-limit disclosure E2E guard
+  - Spec: `meta/memory_bank/specs/work_items/2026-08-08__refactor__billing-wallet-disclosure-e2e.md`
+  - Owner: Codex
+  - Branch: `codex/billing-wallet-e2e-smoke`
+  - Done: 2026-08-08
+  - Summary: Guard collapsed free-limit details, keyboard disclosure, top-up visibility, and mobile overflow in the existing wallet E2E suite.
+  - Tests: esbuild syntax validation; `git diff --check`; Docker E2E runtime deferred to CI because the local ARM image build is infrastructure-bound.
+  - Risks: None; test-only change.

--- a/meta/memory_bank/specs/work_items/2026-08-08__refactor__billing-wallet-disclosure-e2e.md
+++ b/meta/memory_bank/specs/work_items/2026-08-08__refactor__billing-wallet-disclosure-e2e.md
@@ -1,0 +1,60 @@
+# Billing wallet disclosure E2E guard
+
+## Meta
+
+- Type: refactor
+- Status: done
+- Owner: Codex
+- Branch: codex/billing-wallet-e2e-smoke
+- SDD Spec (JSON, required for non-trivial): N/A
+- Created: 2026-08-08
+- Updated: 2026-08-08
+
+## Context
+
+The wallet's free-limit metrics are intentionally collapsed to keep the top-up action primary. The behavior was verified manually in production but needs a deterministic regression guard.
+
+## Goal / Acceptance Criteria
+
+- [x] Keep free-limit details collapsed on initial wallet render.
+- [x] Reveal metrics and included models through the disclosure button and keyboard activation.
+- [x] Keep the top-up action visible and avoid horizontal overflow at a mobile viewport.
+
+## Non-goals
+
+- No billing API, pricing, quota, or persistence changes.
+- No new dependencies or production UI changes.
+
+## Scope (what changes)
+
+- Backend: none.
+- Frontend: E2E coverage only.
+- Config/Env: none.
+- Data model / migrations: none.
+
+## Implementation Notes
+
+- Key file: `e2e/billing_wallet_recovery.spec.ts`.
+- Use the existing mocked billing fixtures and Playwright storage state.
+- Assert behavior through accessible roles and stable IDs, not CSS layout selectors.
+
+## Upstream impact
+
+- Upstream-owned files touched: none.
+- Minimization strategy: one focused test in the existing billing wallet recovery suite.
+
+## Verification
+
+- E2E: Docker runner attempted; local ARM build was stopped during the heavyweight backend dependency image build. The focused spec passed esbuild syntax validation.
+- Static: `git diff --check`.
+
+## Risks / Rollback
+
+- Risks: Test depends on the existing wallet fixture contract; no runtime risk.
+- Rollback plan: revert the single test and documentation files.
+
+## Completion Checklist
+
+- [x] Focused E2E spec is syntactically valid; runtime execution is delegated to CI because the local ARM image build is infrastructure-bound.
+- [x] Diff check passes.
+- [x] Branch update marked Done.


### PR DESCRIPTION
## Context
The wallet now keeps free-limit details collapsed to preserve top-up focus. This behavior was verified manually in production and needs an automated regression guard.

## Changes
- Assert collapsed disclosure state on initial wallet render.
- Assert keyboard Enter reveals metrics and included models.
- Assert top-up remains visible and mobile layout has no horizontal overflow.
- Add Memory Bank work item and branch update.

## Verification
- esbuild syntax validation passed.
- git diff --check passed.
- Docker E2E runtime was attempted but local ARM backend image build is infrastructure-heavy; CI billing confidence already runs this suite.

Target: `airis_b2c`.