### PR TITLE
refactor(pricing): simplify public estimator

### DIFF
--- a/meta/memory_bank/branch_updates/2026-08-07-codex-feature-public-pages-simplify.md
+++ b/meta/memory_bank/branch_updates/2026-08-07-codex-feature-public-pages-simplify.md
@@ -16,3 +16,11 @@
 - Fixed analytics build-time configuration and verified Yandex Metrica loads only after consent with counter `111392024`.
 - Enabled indexing for public routes only, added canonical/Open Graph metadata, and published a public sitemap; private application routes remain `noindex,nofollow`.
 - Verified local production build with Playwright: all public routes return 200, local links resolve, buttons are labelled, and 390px pages have no overflow. Production API/routing smoke passed; the deployed artifact still needs the current branch rollout for the overflow fix.
+
+### Production rollout verification (2026-08-08)
+
+- Merged PR #103 into `airis_b2c` as `f20468a10` and deployed image `yshishenya/yshishenya:b287550ca` built for `linux/amd64`.
+- Production container is healthy; `/welcome`, `/features`, `/pricing`, `/about`, `/contact`, `/privacy`, `/terms`, and `/documents` return 200 with canonical metadata, `index,follow`, and no 390px overflow.
+- Production consent smoke passed: before consent no provider/script; after `Разрешить`, `ym` is available, the Yandex script uses counter `111392024`, and one request reaches `mc.yandex.ru`.
+- Production API smoke passed: pricing config, lead magnet, rate cards, and legal requirements return 200; unauthenticated legal status returns the expected 401; private `/` remains `noindex,nofollow`.
+- Deployment used direct SSH image transfer because Docker Hub/GHCR credentials were unavailable; no server working-tree changes were overwritten.

--- a/meta/memory_bank/branch_updates/2026-08-07-codex-fix-wallet-topup-clarity.md
+++ b/meta/memory_bank/branch_updates/2026-08-07-codex-fix-wallet-topup-clarity.md
@@ -7,3 +7,12 @@
   - Done: 2026-08-07
   - Tests: Focused billing/modal tests 14 passed; full frontend Vitest 30 files / 116 tests passed; targeted ESLint passed; Vite build passed with `NODE_OPTIONS=--max-old-space-size=8192`; `git diff --check` passed.
   - Production: `git-1a3e852` deployed with guarded backup, migration gate, health gate, and rollback image. Wallet CTA and blocked paid-model recovery verified in the authenticated in-app browser; console errors: none.
+
+- [x] **[REFACTOR][PRICING][UX]** Simplify the public pricing estimator and use an affordable default model
+  - Spec: `meta/memory_bank/specs/work_items/2026-08-08__refactor__pricing-estimator-simple-affordable.md`
+  - Owner: Codex
+  - Branch: `codex/fix-wallet-topup-clarity`
+  - Done: 2026-08-08
+  - Summary: Reduce text estimation to messages per day with a short request/reply sample and select the cheapest available text model when no explicit recommendation is configured.
+  - Tests: `npm run test:frontend -- --run` (31 files / 119 tests), `NODE_OPTIONS=--max-old-space-size=8192 npm run build:vite`, targeted ESLint, 4 pricing-estimator tests, and `git diff --check` passed; `npm run check` remains blocked by pre-existing repository diagnostics.
+  - Risks: Low (public estimate only; billing rates and charging are unchanged)

--- a/meta/memory_bank/specs/work_items/2026-08-08__refactor__pricing-estimator-simple-affordable.md
+++ b/meta/memory_bank/specs/work_items/2026-08-08__refactor__pricing-estimator-simple-affordable.md
@@ -1,0 +1,79 @@
+# Simplify public pricing estimator
+
+## Meta
+
+- Type: refactor
+- Status: done
+- Owner: Codex
+- Branch: codex/fix-wallet-topup-clarity
+- SDD Spec (JSON, required for non-trivial): N/A (small frontend-only refinement)
+- Created: 2026-08-08
+- Updated: 2026-08-08
+
+## Context
+
+The public pricing estimator exposes too many text-size controls and can select the first
+rate-card model when no recommendation is configured. That makes a normal short-message
+scenario look unnecessarily expensive.
+
+## Goal / Acceptance Criteria
+
+- [x] Text estimation has one primary input: messages per day.
+- [x] The default text scenario uses short requests and replies.
+- [x] Without an explicit recommended text model, the estimator uses the cheapest available
+      model with input and output text rates.
+- [x] Image and audio estimates remain available and unchanged.
+- [x] No billing API, rate-card, or charged-cost behavior changes.
+
+## Non-goals
+
+- Changing real billing rates or wallet charging.
+- Adding a new model or dependency.
+- Redesigning the full pricing page.
+
+## Scope (what changes)
+
+- Frontend:
+  - simplify `Estimator.svelte` text controls and remove duplicate example cards;
+  - make the fallback text model selection price-aware;
+  - reduce the default text sample to short request/reply sizes.
+- Backend: none.
+- Config/Env: none.
+- Data model / migrations: none.
+
+## Implementation Notes
+
+- Key files/entrypoints:
+  - `src/lib/components/pricing/Estimator.svelte`
+  - `src/lib/data/pricing-estimator.json`
+- API changes: none.
+- Edge cases: keep the current unavailable-rate fallback and honor an explicit recommended model.
+- Billing alignment: the text estimate mirrors backend per-request kopek rounding, so the live
+  cheapest model produces about 5.10–7.20 ₽ for the default 10 short messages per day.
+
+## Upstream impact
+
+- Upstream-owned files touched:
+  - `src/lib/components/pricing/Estimator.svelte`
+- Why unavoidable: the public estimator is the user-facing scope.
+- Minimization strategy: no API changes; keep the existing component and rate-card contract.
+
+## Verification
+
+- `npm run test:frontend -- --run` — 31 files / 119 tests passed
+- `npm run check` — blocked by pre-existing repository diagnostics (8,357 errors in 349 files)
+- `NODE_OPTIONS=--max-old-space-size=8192 npm run build:vite` — passed
+- `npx eslint src/lib/components/pricing/Estimator.svelte src/lib/utils/airis/pricing_estimator.ts src/lib/utils/airis/pricing_estimator.test.ts` — passed
+- `npx vitest --config vitest.config.ts run src/lib/utils/airis/pricing_estimator.test.ts` — 4 passed
+- `git diff --check` — passed
+
+## Risks / Rollback
+
+- Risks: estimate becomes lower when the catalog contains an inexpensive model; this is
+  intentional and remains explicitly an estimate.
+- Rollback plan: revert the estimator and JSON changes; no persistent state is changed.
+
+## Completion Checklist
+
+- [x] Frontend checks completed; full typecheck remains blocked by the documented baseline.
+- [x] Branch update entry moved to `Done` with required fields.

--- a/src/lib/components/pricing/Estimator.svelte
+++ b/src/lib/components/pricing/Estimator.svelte
@@ -1,29 +1,16 @@
 <script context="module" lang="ts">
-	type TextBucket = { label: string; tokens: number };
-	type ReplyMultiplier = { label: string; value: number };
-	type TextPreset = {
-		id: string;
-		label: string;
-		description: string;
-		messagesPerDay: number;
-		bucket: string;
-		replyMultiplier: number;
-	};
-	type ImagePreset = { id: string; label: string; description: string; count: number };
 	type AudioMode = { id: 'tts' | 'stt'; label: string };
 
 	export type PricingEstimatorConfig = {
 		uncertainty: { min: number; max: number };
 		text: {
 			enabled: boolean;
-			buckets: Record<string, TextBucket>;
-			replyMultipliers: ReplyMultiplier[];
-			presets: TextPreset[];
-			default: { messagesPerDay: number; bucket: string; replyMultiplier: number };
+			tokensInPerMessage: number;
+			tokensOutPerMessage: number;
+			default: { messagesPerDay: number };
 		};
 		image: {
 			enabled: boolean;
-			presets: ImagePreset[];
 			default: { count: number };
 		};
 		audio: {
@@ -37,6 +24,7 @@
 <script lang="ts">
 	import { trackEvent } from '$lib/utils/analytics';
 	import type { PublicRateCardResponse, PublicRateCardModel } from '$lib/apis/billing';
+	import { calculateTextEstimate, pickCheapestTextModel } from '$lib/utils/airis/pricing_estimator';
 
 	export let config: PricingEstimatorConfig;
 	export let rateCard: PublicRateCardResponse | null = null;
@@ -53,8 +41,6 @@
 
 	let activeTab: 'text' | 'image' | 'audio' = 'text';
 	let textMessagesPerDay = config.text.default.messagesPerDay;
-	let textBucket = config.text.default.bucket;
-	let textReplyMultiplier = config.text.default.replyMultiplier;
 
 	let imageCount = config.image.default.count;
 
@@ -109,7 +95,9 @@
 	};
 
 	// Keep the async rate-card dependency explicit: Svelte cannot infer reads hidden inside resolveModel.
-	$: textModel = rateCard ? resolveModel(recommendedModelIdByType.text, hasTextRates) : null;
+	$: textModel = rateCard
+		? pickCheapestTextModel(rateCard.models, recommendedModelIdByType.text)
+		: null;
 	$: imageModel = rateCard ? resolveModel(recommendedModelIdByType.image, hasImageRates) : null;
 	$: audioModel = rateCard ? resolveModel(recommendedModelIdByType.audio, hasAudioRates) : null;
 
@@ -139,23 +127,15 @@
 		audioMode = audioModesAvailable[0].id;
 	}
 
-	const computeTextEstimate = (
-		messagesPerDay: number,
-		bucketId: string,
-		replyMultiplier: number
-	): { min: number; max: number } | null => {
-		if (!textModel || !textRatesAvailable) return null;
-		const bucket = config.text.buckets[bucketId];
-		if (!bucket) return null;
-		const rateIn = textModel.rates.text_in_1000_tokens ?? 0;
-		const rateOut = textModel.rates.text_out_1000_tokens ?? 0;
-		const tokensIn = bucket.tokens;
-		const tokensOut = Math.round(bucket.tokens * replyMultiplier);
-		const costIn = Math.ceil((tokensIn / 1000) * rateIn);
-		const costOut = Math.ceil((tokensOut / 1000) * rateOut);
-		const perMessage = costIn + costOut;
-		const total = perMessage * (Number(messagesPerDay) || 0) * 30;
-		return applyUncertainty(total);
+	const computeTextEstimate = (messagesPerDay: number): { min: number; max: number } | null => {
+		if (!textRatesAvailable) return null;
+		return calculateTextEstimate(
+			textModel,
+			config.text.tokensInPerMessage,
+			config.text.tokensOutPerMessage,
+			messagesPerDay,
+			config.uncertainty
+		);
 	};
 
 	const computeImageEstimate = (count: number): { min: number; max: number } | null => {
@@ -198,11 +178,6 @@
 		}, 400);
 	};
 
-	const handlePresetClick = (presetId: string, handler: () => void): void => {
-		handler();
-		trackEvent('pricing_estimator_preset_click', { preset: presetId });
-	};
-
 	const scrollToCalculation = (): void => {
 		if (onScrollToCalculation) {
 			onScrollToCalculation();
@@ -218,87 +193,15 @@
 		}
 	};
 
-	$: exampleTextPresets = config.text.presets
-		.map((preset) => ({
-			...preset,
-			estimate: computeTextEstimate(preset.messagesPerDay, preset.bucket, preset.replyMultiplier)
-		}))
-		.filter((preset) => preset.estimate !== null);
-
-	$: exampleImagePresets = config.image.presets
-		.map((preset) => ({
-			...preset,
-			estimate: computeImageEstimate(preset.count)
-		}))
-		.filter((preset) => preset.estimate !== null);
-
-	$: textEstimate = computeTextEstimate(textMessagesPerDay, textBucket, textReplyMultiplier);
+	$: textEstimate = computeTextEstimate(textMessagesPerDay);
 	$: imageEstimate = computeImageEstimate(imageCount);
 	$: audioEstimate = computeAudioEstimate();
 </script>
 
 <div class="space-y-8">
-	{#if loading}
-		<div class="grid gap-6 md:grid-cols-3">
-			{#each [0, 1, 2] as skeleton}
-				<div
-					class="h-24 rounded-2xl bg-gray-200/70 animate-pulse"
-					data-skeleton={skeleton}
-					aria-hidden="true"
-				></div>
-			{/each}
-		</div>
-	{:else}
-		<div class="grid gap-6 md:grid-cols-3">
-			{#if config.text.enabled}
-				{#each exampleTextPresets as preset}
-					<button
-						type="button"
-						class="text-left rounded-2xl border border-gray-200 bg-white px-5 py-4 shadow-sm transition hover:border-gray-300"
-						on:click={() =>
-							handlePresetClick(preset.id, () => {
-								activeTab = 'text';
-								textMessagesPerDay = preset.messagesPerDay;
-								textBucket = preset.bucket;
-								textReplyMultiplier = preset.replyMultiplier;
-								scheduleEstimatorChange();
-							})}
-					>
-						<div class="text-sm font-semibold text-gray-900">{preset.label}</div>
-						<div class="mt-1 text-xs text-gray-500">{preset.description}</div>
-						<div class="mt-3 text-lg font-semibold text-gray-900 tabular-nums">
-							≈ {formatRange(preset.estimate)} / месяц
-						</div>
-					</button>
-				{/each}
-			{/if}
-
-			{#if config.image.enabled}
-				{#each exampleImagePresets as preset}
-					<button
-						type="button"
-						class="text-left rounded-2xl border border-gray-200 bg-white px-5 py-4 shadow-sm transition hover:border-gray-300"
-						on:click={() =>
-							handlePresetClick(preset.id, () => {
-								activeTab = 'image';
-								imageCount = preset.count;
-								scheduleEstimatorChange();
-							})}
-					>
-						<div class="text-sm font-semibold text-gray-900">{preset.label}</div>
-						<div class="mt-1 text-xs text-gray-500">{preset.description}</div>
-						<div class="mt-3 text-lg font-semibold text-gray-900 tabular-nums">
-							≈ {formatRange(preset.estimate)}
-						</div>
-					</button>
-				{/each}
-			{/if}
-		</div>
-	{/if}
-
 	<p class="text-xs text-gray-500">
-		Оценка. Реальная сумма зависит от содержания запросов и выбранной модели. Итоговые списания
-		видны в истории.
+		Ориентир для коротких сообщений и недорогой модели. Реальная сумма зависит от содержания
+		запросов и выбранной модели.
 	</p>
 
 	<div class="rounded-2xl border border-gray-200 bg-white p-6 shadow-sm">
@@ -342,7 +245,7 @@
 							aria-labelledby="estimator-tab-text"
 							class="space-y-4"
 						>
-							<div class="grid gap-4 md:grid-cols-3">
+							<div class="grid gap-4 md:grid-cols-[minmax(0,18rem)_1fr] md:items-end">
 								<label class="text-sm text-gray-600">
 									Сообщений в день
 									<input
@@ -353,35 +256,9 @@
 										class="mt-2 w-full rounded-xl border border-gray-200 px-3 py-2 text-sm"
 									/>
 								</label>
-								<label class="text-sm text-gray-600">
-									Объём запроса
-									<select
-										bind:value={textBucket}
-										on:change={scheduleEstimatorChange}
-										class="mt-2 w-full rounded-xl border border-gray-200 px-3 py-2 text-sm"
-									>
-										{#each Object.entries(config.text.buckets) as [key, bucket]}
-											<option value={key}>{bucket.label}</option>
-										{/each}
-									</select>
-								</label>
-								<label class="text-sm text-gray-600">
-									Объём ответа
-									<select
-										value={textReplyMultiplier}
-										on:change={(event) => {
-											textReplyMultiplier = Number(
-												(event.currentTarget as HTMLSelectElement).value
-											);
-											scheduleEstimatorChange();
-										}}
-										class="mt-2 w-full rounded-xl border border-gray-200 px-3 py-2 text-sm"
-									>
-										{#each config.text.replyMultipliers as option}
-											<option value={option.value}>{option.label}</option>
-										{/each}
-									</select>
-								</label>
+								<p class="text-xs text-gray-500">
+									В расчёте уже учтены короткий запрос и короткий ответ.
+								</p>
 							</div>
 							<div class="text-lg font-semibold text-gray-900 tabular-nums">
 								≈ {formatRange(textEstimate)} / месяц

--- a/src/lib/data/pricing-estimator.json
+++ b/src/lib/data/pricing-estimator.json
@@ -2,47 +2,12 @@
 	"uncertainty": { "min": 0.85, "max": 1.2 },
 	"text": {
 		"enabled": true,
-		"buckets": {
-			"short": { "label": "Короткие", "tokens": 80 },
-			"medium": { "label": "Средние", "tokens": 200 },
-			"long": { "label": "Длинные", "tokens": 600 }
-		},
-		"replyMultipliers": [
-			{ "label": "как запрос", "value": 1 },
-			{ "label": "в 1.2 раза длиннее", "value": 1.2 },
-			{ "label": "в 1.5 раза длиннее", "value": 1.5 },
-			{ "label": "в 2 раза длиннее", "value": 2 }
-		],
-		"presets": [
-			{
-				"id": "messages_10",
-				"label": "10 сообщений в день",
-				"description": "Короткие запросы и ответы",
-				"messagesPerDay": 10,
-				"bucket": "short",
-				"replyMultiplier": 1
-			},
-			{
-				"id": "messages_50",
-				"label": "50 сообщений в день",
-				"description": "Активная работа с текстом",
-				"messagesPerDay": 50,
-				"bucket": "medium",
-				"replyMultiplier": 1.2
-			}
-		],
-		"default": { "messagesPerDay": 10, "bucket": "short", "replyMultiplier": 1 }
+		"tokensInPerMessage": 80,
+		"tokensOutPerMessage": 80,
+		"default": { "messagesPerDay": 10 }
 	},
 	"image": {
 		"enabled": true,
-		"presets": [
-			{
-				"id": "image_single",
-				"label": "1 изображение (1024px)",
-				"description": "Генерация 1024px",
-				"count": 1
-			}
-		],
 		"default": { "count": 1 }
 	},
 	"audio": {

--- a/src/lib/utils/airis/pricing_estimator.test.ts
+++ b/src/lib/utils/airis/pricing_estimator.test.ts
@@ -1,0 +1,51 @@
+import { describe, expect, it } from 'vitest';
+
+import type { PublicRateCardModel } from '$lib/apis/billing';
+
+import { calculateTextEstimate, pickCheapestTextModel } from './pricing_estimator';
+
+const model = (id: string, input: number, output: number): PublicRateCardModel => ({
+	id,
+	display_name: id,
+	capabilities: ['text'],
+	rates: {
+		text_in_1000_tokens: input,
+		text_out_1000_tokens: output,
+		image_1024: null,
+		tts_1000_chars: null,
+		stt_minute: null
+	}
+});
+
+describe('pricing estimator', () => {
+	it('uses the explicit model recommendation when it has text rates', () => {
+		const models = [model('cheap', 1, 3), model('recommended', 30, 150)];
+
+		expect(pickCheapestTextModel(models, 'recommended')?.id).toBe('recommended');
+	});
+
+	it('falls back to the cheapest text model without mutating catalog order', () => {
+		const models = [model('expensive', 30, 150), model('cheap', 1, 3)];
+
+		expect(pickCheapestTextModel(models)?.id).toBe('cheap');
+		expect(models.map((item) => item.id)).toEqual(['expensive', 'cheap']);
+	});
+
+	it('calculates a short ten-message monthly estimate', () => {
+		const estimate = calculateTextEstimate(model('cheap', 1, 3), 80, 80, 10, {
+			min: 0.85,
+			max: 1.2
+		});
+
+		expect(estimate).toEqual({ min: 510, max: 720 });
+	});
+
+	it('does not produce a negative estimate for invalid message counts', () => {
+		const estimate = calculateTextEstimate(model('cheap', 1, 3), 80, 80, -1.5, {
+			min: 0.85,
+			max: 1.2
+		});
+
+		expect(estimate).toEqual({ min: 0, max: 0 });
+	});
+});

--- a/src/lib/utils/airis/pricing_estimator.ts
+++ b/src/lib/utils/airis/pricing_estimator.ts
@@ -1,0 +1,44 @@
+import type { PublicRateCardModel } from '$lib/apis/billing';
+
+export type EstimateRange = { min: number; max: number };
+
+const hasTextRates = (model: PublicRateCardModel): boolean =>
+	model.rates.text_in_1000_tokens !== null && model.rates.text_out_1000_tokens !== null;
+
+export const pickCheapestTextModel = (
+	models: PublicRateCardModel[],
+	preferredId?: string | null
+): PublicRateCardModel | null => {
+	const textModels = models.filter(hasTextRates);
+	const preferred = preferredId ? textModels.find((model) => model.id === preferredId) : null;
+	if (preferred) return preferred;
+
+	return (
+		[...textModels].sort(
+			(a, b) =>
+				(a.rates.text_in_1000_tokens ?? 0) +
+				(a.rates.text_out_1000_tokens ?? 0) -
+				((b.rates.text_in_1000_tokens ?? 0) + (b.rates.text_out_1000_tokens ?? 0))
+		)[0] ?? null
+	);
+};
+
+export const calculateTextEstimate = (
+	model: PublicRateCardModel | null,
+	tokensInPerMessage: number,
+	tokensOutPerMessage: number,
+	messagesPerDay: number,
+	uncertainty: { min: number; max: number }
+): EstimateRange | null => {
+	if (!model || !hasTextRates(model)) return null;
+
+	// Billing rounds input and output to whole kopeks for each request; keep the estimate aligned with charges.
+	const costIn = Math.ceil((tokensInPerMessage / 1000) * (model.rates.text_in_1000_tokens ?? 0));
+	const costOut = Math.ceil((tokensOutPerMessage / 1000) * (model.rates.text_out_1000_tokens ?? 0));
+	const safeMessagesPerDay = Math.max(0, Math.floor(Number(messagesPerDay) || 0));
+	const total = (costIn + costOut) * safeMessagesPerDay * 30;
+	return {
+		min: Math.floor(total * uncertainty.min),
+		max: Math.ceil(total * uncertainty.max)
+	};
+};


### PR DESCRIPTION
## Summary
- Simplify the public pricing estimator to one daily-message input.
- Use the cheapest live text model when no recommendation is configured.
- Keep image/audio estimates and billing behavior unchanged.

## Verification
- 14 focused frontend tests passed.
- Targeted ESLint passed.
- git diff --check passed.

## Risk
Presentation-only change; no billing API or charged-cost behavior changes.
