### PR TITLE
fix: serve prerendered landing routes

### DIFF
--- a/backend/open_webui/main.py
+++ b/backend/open_webui/main.py
@@ -298,8 +298,16 @@ class SPAStaticFiles(StaticFiles):
                 if path.endswith('.js'):
                     # Return 404 for javascript files
                     raise ex
-                else:
-                    return await super().get_response('index.html', scope)
+
+                route_path = path.strip('/')
+                if route_path and '/' not in route_path and '.' not in route_path:
+                    try:
+                        return await super().get_response(f'{route_path}.html', scope)
+                    except (HTTPException, StarletteHTTPException) as route_ex:
+                        if route_ex.status_code != 404:
+                            raise route_ex
+
+                return await super().get_response('index.html', scope)
             else:
                 raise ex
 

--- a/meta/memory_bank/branch_updates/2026-08-08-codex-fix-wallet-topup-clarity.md
+++ b/meta/memory_bank/branch_updates/2026-08-08-codex-fix-wallet-topup-clarity.md
@@ -1,5 +1,14 @@
 ### Done
 
+- [x] **[BUG]** Serve prerendered landing HTML on production
+  - Spec: `meta/memory_bank/specs/work_items/2026-08-08__bugfix__serve-prerendered-landing-pages.md`
+  - Owner: Codex
+  - Branch: `codex/fix-wallet-topup-clarity`
+  - Done: 2026-08-08
+  - Summary: Backend now resolves adapter-static route HTML before the SPA fallback so direct landing requests receive real prerendered content.
+  - Tests: Production smoke check pending redeploy
+  - Risks: N/A
+
 - [x] **[BUG]** Harden public landing SSR, navigation, and analytics
   - Spec: `meta/memory_bank/specs/work_items/2026-08-08__bugfix__landing-ssr-analytics.md`
   - Owner: Codex

--- a/meta/memory_bank/branch_updates/2026-08-08-codex-fix-wallet-topup-clarity.md
+++ b/meta/memory_bank/branch_updates/2026-08-08-codex-fix-wallet-topup-clarity.md
@@ -6,7 +6,7 @@
   - Branch: `codex/fix-wallet-topup-clarity`
   - Done: 2026-08-08
   - Summary: Backend now resolves adapter-static route HTML before the SPA fallback so direct landing requests receive real prerendered content.
-  - Tests: Production smoke check pending redeploy
+  - Tests: Production `/health` 200; all eight public routes return 200 with prerendered `<h1>` in HTML; Playwright production smoke passed.
   - Risks: N/A
 
 - [x] **[BUG]** Harden public landing SSR, navigation, and analytics

--- a/meta/memory_bank/specs/work_items/2026-08-08__bugfix__serve-prerendered-landing-pages.md
+++ b/meta/memory_bank/specs/work_items/2026-08-08__bugfix__serve-prerendered-landing-pages.md
@@ -60,4 +60,4 @@ The frontend build contains route-specific prerendered HTML files, but the backe
 ## Completion Checklist
 
 - [x] Implementation completed.
-- [ ] Production route smoke check completed after redeploy.
+- [x] Production route smoke check completed after redeploy.

--- a/meta/memory_bank/specs/work_items/2026-08-08__bugfix__serve-prerendered-landing-pages.md
+++ b/meta/memory_bank/specs/work_items/2026-08-08__bugfix__serve-prerendered-landing-pages.md
@@ -1,0 +1,63 @@
+# Serve prerendered landing pages
+
+## Meta
+
+- Type: bugfix
+- Status: done
+- Owner: Codex
+- Branch: codex/fix-wallet-topup-clarity
+- SDD Spec (JSON, required for non-trivial): N/A (small targeted fallback fix)
+- Created: 2026-08-08
+- Updated: 2026-08-08
+
+## Context
+
+The frontend build contains route-specific prerendered HTML files, but the backend SPA static fallback only looked for `index.html`. Direct production requests therefore received the application shell instead of the landing page HTML.
+
+## Goal / Acceptance Criteria
+
+- [x] Direct requests to one-segment prerendered routes serve `<route>.html`.
+- [x] Unknown routes continue to fall back to `index.html`.
+- [x] JavaScript asset 404 behavior remains unchanged.
+
+## Non-goals
+
+- No changes to route content, frontend navigation, or API behavior.
+
+## Scope (what changes)
+
+- Backend:
+  - Resolve adapter-static route HTML before the existing SPA fallback.
+
+## Implementation Notes
+
+- Key files/entrypoints:
+  - `backend/open_webui/main.py:SPAStaticFiles`
+- Edge cases:
+  - Only one-segment extensionless paths are mapped, avoiding asset and nested API paths.
+
+## Upstream impact
+
+- Upstream-owned files touched:
+  - `backend/open_webui/main.py`
+- Why unavoidable:
+  - The backend owns production static-file fallback behavior.
+- Minimization strategy (thin hooks / additive modules / guarded behavior):
+  - Small guarded lookup before the existing fallback; all other behavior is unchanged.
+
+## Verification
+
+- `npm run build:vite`
+- Production smoke check: `curl -fsS https://chat.airis.you/welcome` contains the prerendered landing `<h1>`.
+
+## Risks / Rollback
+
+- Risks:
+  - None expected; missing route HTML falls through to the existing SPA shell.
+- Rollback plan:
+  - Revert the single `SPAStaticFiles` change and redeploy the previous image.
+
+## Completion Checklist
+
+- [x] Implementation completed.
+- [ ] Production route smoke check completed after redeploy.


### PR DESCRIPTION
## Context
Production had route-specific prerendered HTML files in the image, but direct requests such as `/welcome` were served `index.html` by the backend SPA fallback.

## Changes
- Resolve one-segment adapter-static route HTML before the SPA fallback.
- Preserve existing JavaScript 404 and unknown-route behavior.
- Record production smoke verification in the memory bank.

## Verification
- `python -m py_compile backend/open_webui/main.py`
- `git diff --check`
- Production `/health`: 200
- Production public routes `/welcome`, `/features`, `/pricing`, `/about`, `/contact`, `/privacy`, `/terms`, `/documents`: 200 with prerendered `<h1>`
- Playwright production smoke in mobile viewport
