### PR TITLE
fix(pricing): Model cumulative chat context

### DIFF
--- a/meta/memory_bank/branch_updates/2026-08-08-codex-fix-pricing-estimator-context.md
+++ b/meta/memory_bank/branch_updates/2026-08-08-codex-fix-pricing-estimator-context.md
@@ -1,0 +1,9 @@
+- [x] **[BUGFIX][PRICING][UX]** Account for cumulative chat context in the public pricing estimator
+  - Spec: `meta/memory_bank/specs/work_items/2026-08-08__refactor__pricing-estimator-simple-affordable.md`
+  - Owner: Codex
+  - Branch: `codex/fix/pricing-estimator-context`
+  - Started: 2026-08-08
+  - Done: 2026-08-08
+  - Summary: Model one continuing chat, prefer an affordable working text model, and keep the estimator around 500–1000 ₽ for the default 10 messages per day.
+  - Tests: `npm run test:frontend -- --run` (32 files / 123 tests), `NODE_OPTIONS=--max-old-space-size=8192 npm run build:vite`, targeted ESLint, 4 pricing-estimator tests, and `git diff --check` passed.
+  - Risks: Estimate is conservative for one long chat; separate chats or shorter replies cost less.

--- a/meta/memory_bank/specs/work_items/2026-08-08__refactor__pricing-estimator-simple-affordable.md
+++ b/meta/memory_bank/specs/work_items/2026-08-08__refactor__pricing-estimator-simple-affordable.md
@@ -5,7 +5,7 @@
 - Type: refactor
 - Status: done
 - Owner: Codex
-- Branch: codex/fix-wallet-topup-clarity
+- Branch: codex/fix/pricing-estimator-context
 - SDD Spec (JSON, required for non-trivial): N/A (small frontend-only refinement)
 - Created: 2026-08-08
 - Updated: 2026-08-08
@@ -13,15 +13,15 @@
 ## Context
 
 The public pricing estimator exposes too many text-size controls and can select the first
-rate-card model when no recommendation is configured. That makes a normal short-message
-scenario look unnecessarily expensive.
+rate-card model when no recommendation is configured. A fixed short-message sample also
+ignores that a continuing chat sends its previous context again on every request.
 
 ## Goal / Acceptance Criteria
 
 - [x] Text estimation has one primary input: messages per day.
-- [x] The default text scenario uses short requests and replies.
-- [x] Without an explicit recommended text model, the estimator uses the cheapest available
-      model with input and output text rates.
+- [x] The default text scenario uses short messages while accumulating one chat's context.
+- [x] The estimator uses an affordable working model when it is available, with a safe cheapest
+      model fallback.
 - [x] Image and audio estimates remain available and unchanged.
 - [x] No billing API, rate-card, or charged-cost behavior changes.
 
@@ -35,8 +35,8 @@ scenario look unnecessarily expensive.
 
 - Frontend:
   - simplify `Estimator.svelte` text controls and remove duplicate example cards;
-  - make the fallback text model selection price-aware;
-  - reduce the default text sample to short request/reply sizes.
+  - prefer an affordable working model and keep the cheapest-model fallback;
+  - account for accumulated context while keeping short request/reply defaults.
 - Backend: none.
 - Config/Env: none.
 - Data model / migrations: none.
@@ -48,8 +48,9 @@ scenario look unnecessarily expensive.
   - `src/lib/data/pricing-estimator.json`
 - API changes: none.
 - Edge cases: keep the current unavailable-rate fallback and honor an explicit recommended model.
-- Billing alignment: the text estimate mirrors backend per-request kopek rounding, so the live
-  cheapest model produces about 5.10–7.20 ₽ for the default 10 short messages per day.
+- Billing alignment: the text estimate mirrors backend per-request kopek rounding and sends
+  previous turns again; the current Qwen 3.7 Plus scenario produces about 623–880 ₽ for
+  10 messages per day.
 
 ## Upstream impact
 
@@ -60,7 +61,7 @@ scenario look unnecessarily expensive.
 
 ## Verification
 
-- `npm run test:frontend -- --run` — 31 files / 119 tests passed
+- `npm run test:frontend -- --run` — 32 files / 123 tests passed
 - `npm run check` — blocked by pre-existing repository diagnostics (8,357 errors in 349 files)
 - `NODE_OPTIONS=--max-old-space-size=8192 npm run build:vite` — passed
 - `npx eslint src/lib/components/pricing/Estimator.svelte src/lib/utils/airis/pricing_estimator.ts src/lib/utils/airis/pricing_estimator.test.ts` — passed
@@ -69,8 +70,8 @@ scenario look unnecessarily expensive.
 
 ## Risks / Rollback
 
-- Risks: estimate becomes lower when the catalog contains an inexpensive model; this is
-  intentional and remains explicitly an estimate.
+- Risks: a single continuously growing chat is a conservative scenario; real usage is lower when
+  users split work across multiple chats or send shorter replies.
 - Rollback plan: revert the estimator and JSON changes; no persistent state is changed.
 
 ## Completion Checklist

--- a/src/lib/components/pricing/Estimator.svelte
+++ b/src/lib/components/pricing/Estimator.svelte
@@ -5,6 +5,7 @@
 		uncertainty: { min: number; max: number };
 		text: {
 			enabled: boolean;
+			modelId?: string;
 			tokensInPerMessage: number;
 			tokensOutPerMessage: number;
 			default: { messagesPerDay: number };
@@ -96,7 +97,8 @@
 
 	// Keep the async rate-card dependency explicit so the estimate recalculates after the API response.
 	$: rateCardModels = rateCard?.models ?? [];
-	$: textModel = pickCheapestTextModel(rateCardModels, recommendedModelIdByType.text);
+	$: textModelPreference = config.text.modelId ?? recommendedModelIdByType.text;
+	$: textModel = pickCheapestTextModel(rateCardModels, textModelPreference);
 	$: imageModel = rateCard ? resolveModel(recommendedModelIdByType.image, hasImageRates) : null;
 	$: audioModel = rateCard ? resolveModel(recommendedModelIdByType.audio, hasAudioRates) : null;
 
@@ -200,8 +202,8 @@
 
 <div class="space-y-8">
 	<p class="text-xs text-gray-500">
-		Ориентир для коротких сообщений и недорогой модели. Реальная сумма зависит от содержания
-		запросов и выбранной модели.
+		Ориентир для обычного длинного чата: история сообщений тоже учитывается. Реальная сумма зависит
+		от содержания запросов и выбранной модели.
 	</p>
 
 	<div class="rounded-2xl border border-gray-200 bg-white p-6 shadow-sm">
@@ -257,7 +259,7 @@
 									/>
 								</label>
 								<p class="text-xs text-gray-500">
-									В расчёте уже учтены короткий запрос и короткий ответ.
+									В расчёте учитывается накопление истории одного чата.
 								</p>
 							</div>
 							<div class="text-lg font-semibold text-gray-900 tabular-nums">

--- a/src/lib/data/pricing-estimator.json
+++ b/src/lib/data/pricing-estimator.json
@@ -2,6 +2,7 @@
 	"uncertainty": { "min": 0.85, "max": 1.2 },
 	"text": {
 		"enabled": true,
+		"modelId": "qwen3.7-plus",
 		"tokensInPerMessage": 80,
 		"tokensOutPerMessage": 80,
 		"default": { "messagesPerDay": 10 }

--- a/src/lib/utils/airis/pricing_estimator.test.ts
+++ b/src/lib/utils/airis/pricing_estimator.test.ts
@@ -31,13 +31,13 @@ describe('pricing estimator', () => {
 		expect(models.map((item) => item.id)).toEqual(['expensive', 'cheap']);
 	});
 
-	it('calculates a short ten-message monthly estimate', () => {
-		const estimate = calculateTextEstimate(model('cheap', 1, 3), 80, 80, 10, {
+	it('calculates a cumulative-context monthly estimate', () => {
+		const estimate = calculateTextEstimate(model('balanced', 10, 39), 80, 80, 10, {
 			min: 0.85,
 			max: 1.2
 		});
 
-		expect(estimate).toEqual({ min: 510, max: 720 });
+		expect(estimate).toEqual({ min: 62322, max: 87984 });
 	});
 
 	it('does not produce a negative estimate for invalid message counts', () => {

--- a/src/lib/utils/airis/pricing_estimator.ts
+++ b/src/lib/utils/airis/pricing_estimator.ts
@@ -32,11 +32,21 @@ export const calculateTextEstimate = (
 ): EstimateRange | null => {
 	if (!model || !hasTextRates(model)) return null;
 
-	// Billing rounds input and output to whole kopeks for each request; keep the estimate aligned with charges.
-	const costIn = Math.ceil((tokensInPerMessage / 1000) * (model.rates.text_in_1000_tokens ?? 0));
-	const costOut = Math.ceil((tokensOutPerMessage / 1000) * (model.rates.text_out_1000_tokens ?? 0));
 	const safeMessagesPerDay = Math.max(0, Math.floor(Number(messagesPerDay) || 0));
-	const total = (costIn + costOut) * safeMessagesPerDay * 30;
+	const totalMessages = safeMessagesPerDay * 30;
+	const rateIn = model.rates.text_in_1000_tokens ?? 0;
+	const rateOut = model.rates.text_out_1000_tokens ?? 0;
+	let total = 0;
+
+	for (let messageIndex = 0; messageIndex < totalMessages; messageIndex += 1) {
+		// Each request sends the previous conversation turns again; billing rounds each request to kopeks.
+		const contextTokens =
+			tokensInPerMessage + messageIndex * (tokensInPerMessage + tokensOutPerMessage);
+		const costIn = Math.ceil((contextTokens / 1000) * rateIn);
+		const costOut = Math.ceil((tokensOutPerMessage / 1000) * rateOut);
+		total += costIn + costOut;
+	}
+
 	return {
 		min: Math.floor(total * uncertainty.min),
 		max: Math.ceil(total * uncertainty.max)


### PR DESCRIPTION
## Summary

- Simplify the public pricing estimator to one primary input: messages per day.
- Account for cumulative conversation context being sent with each subsequent request.
- Prefer the affordable Qwen 3.7 Plus model when available, with a cheapest-model fallback.
- Keep the default scenario around 623–880 ₽/month for 10 messages per day.

## Root cause

The estimator used a fixed 80-token request and 80-token response for every message. It did not include the previous conversation turns, so the public estimate was unrealistically low.

## Validation

- `npm run test:frontend -- --run` — 32 files / 123 tests passed
- `NODE_OPTIONS=--max-old-space-size=8192 npm run build:vite` — passed
- Targeted ESLint — passed
- Pricing estimator tests — 4 passed
- `git diff --check` — passed

## Risk

The estimate models one continuously growing chat. Separate chats or shorter replies will cost less. No backend billing or rate-card behavior changed.