### PR TITLE
fix: align billing e2e disclosure assertions

### DIFF
--- a/e2e/billing_lead_magnet.spec.ts
+++ b/e2e/billing_lead_magnet.spec.ts
@@ -87,15 +87,11 @@ test.describe('Billing Lead Magnet', () => {
 		await page.waitForURL(/\/billing\/balance/);
 		await page.waitForResponse('**/api/v1/billing/lead-magnet');
 
-		const analyticsDialog = page
-			.getByRole('dialog')
-			.filter({ hasText: /аналитики|analytics/i });
-		const dismissAnalyticsButton = analyticsDialog.getByRole('button', {
-			name: /Не сейчас|Not now|No thanks|Later/i
-		});
-		if ((await dismissAnalyticsButton.count()) > 0) {
-			await dismissAnalyticsButton.first().click();
-		}
+		await page
+			.getByRole('button', { name: /Не сейчас|Not now|No thanks|Later/i })
+			.first()
+			.click({ timeout: 5_000 })
+			.catch(() => undefined);
 
 		const leadMagnetSection = page.getByTestId('lead-magnet-section');
 		await expect(leadMagnetSection.getByText('Free limit')).toBeVisible();

--- a/e2e/billing_lead_magnet.spec.ts
+++ b/e2e/billing_lead_magnet.spec.ts
@@ -88,9 +88,11 @@ test.describe('Billing Lead Magnet', () => {
 		await page.waitForResponse('**/api/v1/billing/lead-magnet');
 
 		await page
+			.getByRole('dialog')
+			.filter({ hasText: /аналитики|analytics/i })
 			.getByRole('button', { name: /Не сейчас|Not now|No thanks|Later/i })
 			.first()
-			.click({ timeout: 5_000 })
+			.click({ timeout: 30_000 })
 			.catch(() => undefined);
 
 		const leadMagnetSection = page.getByTestId('lead-magnet-section');

--- a/e2e/billing_lead_magnet.spec.ts
+++ b/e2e/billing_lead_magnet.spec.ts
@@ -87,14 +87,6 @@ test.describe('Billing Lead Magnet', () => {
 		await page.waitForURL(/\/billing\/balance/);
 		await page.waitForResponse('**/api/v1/billing/lead-magnet');
 
-		await page
-			.getByRole('dialog')
-			.filter({ hasText: /аналитики|analytics/i })
-			.getByRole('button', { name: /Не сейчас|Not now|No thanks|Later/i })
-			.first()
-			.click({ timeout: 30_000 })
-			.catch(() => undefined);
-
 		const leadMagnetSection = page.getByTestId('lead-magnet-section');
 		await expect(leadMagnetSection.getByText('Free limit')).toBeVisible();
 		await expect(leadMagnetSection.getByText('Next reset')).toBeVisible();

--- a/e2e/billing_lead_magnet.spec.ts
+++ b/e2e/billing_lead_magnet.spec.ts
@@ -90,6 +90,9 @@ test.describe('Billing Lead Magnet', () => {
 		const leadMagnetSection = page.getByTestId('lead-magnet-section');
 		await expect(leadMagnetSection.getByText('Free limit')).toBeVisible();
 		await expect(leadMagnetSection.getByText('Next reset')).toBeVisible();
+		const limitsButton = leadMagnetSection.locator('button[aria-controls="free-limit-details"]');
+		await expect(limitsButton).toHaveAttribute('aria-expanded', 'false');
+		await limitsButton.click();
 		await expect(leadMagnetSection.getByText('Text', { exact: true })).toBeVisible();
 		await expect(leadMagnetSection.getByText('Input', { exact: true })).toBeVisible();
 	});
@@ -101,6 +104,9 @@ test.describe('Billing Lead Magnet', () => {
 		const leadMagnetSection = page.getByTestId('lead-magnet-section');
 		await expect(leadMagnetSection.getByText('Free limit')).toBeVisible();
 		await expect(leadMagnetSection.getByText('Next reset')).toBeVisible();
+		const limitsButton = leadMagnetSection.locator('button[aria-controls="free-limit-details"]');
+		await expect(limitsButton).toHaveAttribute('aria-expanded', 'false');
+		await limitsButton.click();
 		await expect(leadMagnetSection.getByText('Output', { exact: true })).toBeVisible();
 	});
 });

--- a/e2e/billing_lead_magnet.spec.ts
+++ b/e2e/billing_lead_magnet.spec.ts
@@ -87,6 +87,16 @@ test.describe('Billing Lead Magnet', () => {
 		await page.waitForURL(/\/billing\/balance/);
 		await page.waitForResponse('**/api/v1/billing/lead-magnet');
 
+		const analyticsDialog = page
+			.getByRole('dialog')
+			.filter({ hasText: /аналитики|analytics/i });
+		const dismissAnalyticsButton = analyticsDialog.getByRole('button', {
+			name: /Не сейчас|Not now|No thanks|Later/i
+		});
+		if ((await dismissAnalyticsButton.count()) > 0) {
+			await dismissAnalyticsButton.first().click();
+		}
+
 		const leadMagnetSection = page.getByTestId('lead-magnet-section');
 		await expect(leadMagnetSection.getByText('Free limit')).toBeVisible();
 		await expect(leadMagnetSection.getByText('Next reset')).toBeVisible();

--- a/e2e/billing_wallet.spec.ts
+++ b/e2e/billing_wallet.spec.ts
@@ -208,6 +208,7 @@ test.describe('Billing Wallet', () => {
 		});
 
 		await page.goto('/billing/balance');
+		await page.waitForResponse('**/api/v1/billing/balance');
 		const heroHeading = page.getByRole('heading', { name: 'Wallet' });
 		await expect(heroHeading).toBeVisible();
 		const heroRow = heroHeading.locator('xpath=../../..');

--- a/e2e/billing_wallet_recovery.spec.ts
+++ b/e2e/billing_wallet_recovery.spec.ts
@@ -167,7 +167,7 @@ test.describe('Billing wallet recovery (smoke)', () => {
 		await page.waitForResponse('**/api/v1/billing/lead-magnet');
 
 		const leadMagnetSection = page.getByTestId('lead-magnet-section');
-		const limitsButton = leadMagnetSection.getByRole('button', { name: 'Limits', exact: true });
+		const limitsButton = leadMagnetSection.locator('button[aria-controls="free-limit-details"]');
 		await expect(limitsButton).toHaveAttribute('aria-expanded', 'false');
 		await expect(leadMagnetSection.locator('#free-limit-details')).toHaveCount(0);
 		await expect(page.getByTestId('topup-proceed')).toBeVisible();
@@ -177,7 +177,6 @@ test.describe('Billing wallet recovery (smoke)', () => {
 		);
 		expect(hasHorizontalOverflow).toBe(false);
 
-		await limitsButton.focus();
 		await limitsButton.press('Enter');
 		await expect(limitsButton).toHaveAttribute('aria-expanded', 'true');
 		await expect(leadMagnetSection.locator('#free-limit-details')).toBeVisible();

--- a/e2e/global-setup.ts
+++ b/e2e/global-setup.ts
@@ -71,6 +71,15 @@ const acceptLegalGateIfPresent = async (page: import('@playwright/test').Page): 
 	await gateContainer.waitFor({ state: 'detached', timeout: 30_000 }).catch(() => undefined);
 };
 
+const dismissChangelogIfPresent = async (page: import('@playwright/test').Page): Promise<void> => {
+	const changelogDialog = page.getByRole('dialog').filter({ hasText: "What's New" });
+	const dismissButton = changelogDialog.getByRole('button', {
+		name: /Okay, Let's Go!|Close/
+	});
+
+	await dismissButton.first().click({ timeout: 30_000 }).catch(() => undefined);
+};
+
 const globalSetup = async (): Promise<void> => {
 	const requestContext = await request.newContext({ baseURL });
 	await waitForBackend(requestContext);
@@ -145,10 +154,7 @@ const globalSetup = async (): Promise<void> => {
 		}, retryToken);
 
 		await page.goto(new URL('/', baseURL).toString());
-		const changelogButton = page.getByRole('button', { name: "Okay, Let's Go!" });
-		if ((await changelogButton.count()) > 0) {
-			await changelogButton.click();
-		}
+		await dismissChangelogIfPresent(page);
 
 		await context.storageState({ path: storageStatePath });
 		await browser.close();
@@ -177,15 +183,7 @@ const globalSetup = async (): Promise<void> => {
 	}, token);
 
 	await page.goto(new URL('/', baseURL).toString());
-	const changelogButton = page.getByRole('button', { name: "Okay, Let's Go!" });
-	if ((await changelogButton.count()) > 0) {
-		await changelogButton.click();
-	}
-	const whatsNewDialog = page.getByRole('dialog').filter({ hasText: "What's New" });
-	const whatsNewCloseButton = whatsNewDialog.getByRole('button', { name: 'Close' });
-	if ((await whatsNewCloseButton.count()) > 0) {
-		await whatsNewCloseButton.first().click();
-	}
+	await dismissChangelogIfPresent(page);
 	await acceptLegalGateIfPresent(page);
 
 	await context.storageState({ path: storageStatePath });

--- a/e2e/global-setup.ts
+++ b/e2e/global-setup.ts
@@ -141,6 +141,7 @@ const globalSetup = async (): Promise<void> => {
 		await page.addInitScript((authToken: string) => {
 			window.localStorage.setItem('token', authToken);
 			window.localStorage.setItem('locale', 'en-US');
+			window.localStorage.setItem('airis.analytics.consent.v1', 'denied');
 		}, retryToken);
 
 		await page.goto(new URL('/', baseURL).toString());
@@ -172,6 +173,7 @@ const globalSetup = async (): Promise<void> => {
 	await page.addInitScript((authToken: string) => {
 		window.localStorage.setItem('token', authToken);
 		window.localStorage.setItem('locale', 'en-US');
+		window.localStorage.setItem('airis.analytics.consent.v1', 'denied');
 	}, token);
 
 	await page.goto(new URL('/', baseURL).toString());

--- a/meta/memory_bank/branch_updates/2026-08-08-codex-fix-billing-e2e-disclosure.md
+++ b/meta/memory_bank/branch_updates/2026-08-08-codex-fix-billing-e2e-disclosure.md
@@ -1,0 +1,10 @@
+### Done
+
+- [x] **[BUG][CI][BILLING]** Align billing E2E disclosure assertions with collapsed wallet UX
+  - Spec: `meta/memory_bank/specs/work_items/2026-08-08__bugfix__billing-e2e-disclosure-expectations.md`
+  - Owner: Codex
+  - Branch: `codex/fix-billing-e2e-disclosure`
+  - Done: 2026-08-08
+  - Summary: Fixed stale expanded-state expectations and replaced the dynamic accessible-name locator with a stable disclosure selector.
+  - Tests: esbuild syntax validation; git diff check; GitHub billing confidence E2E pending.
+  - Risks: Low; test-only.

--- a/meta/memory_bank/branch_updates/2026-08-08-codex-fix-billing-e2e-disclosure.md
+++ b/meta/memory_bank/branch_updates/2026-08-08-codex-fix-billing-e2e-disclosure.md
@@ -8,3 +8,12 @@
   - Summary: Fixed stale expanded-state expectations and replaced the dynamic accessible-name locator with a stable disclosure selector.
   - Tests: esbuild syntax validation; git diff check; GitHub billing confidence E2E pending.
   - Risks: Low; test-only.
+
+- [x] **[BUG][CI][BILLING]** Stabilize shared E2E startup and wallet readiness
+  - Spec: `meta/memory_bank/specs/work_items/2026-08-08__bugfix__billing-e2e-disclosure-expectations.md`
+  - Owner: Codex
+  - Branch: `codex/fix-billing-e2e-disclosure`
+  - Done: 2026-08-08
+  - Summary: Wait for the asynchronous release-notes modal before dismissing it in global setup and wait for the mocked balance response before asserting the wallet hero.
+  - Tests: esbuild syntax validation; git diff check; GitHub billing confidence E2E after push.
+  - Risks: Low; test-only synchronization.

--- a/meta/memory_bank/specs/work_items/2026-08-08__bugfix__billing-e2e-disclosure-expectations.md
+++ b/meta/memory_bank/specs/work_items/2026-08-08__bugfix__billing-e2e-disclosure-expectations.md
@@ -1,0 +1,57 @@
+# Billing E2E disclosure expectations
+
+## Meta
+
+- Type: bugfix
+- Status: done
+- Owner: Codex
+- Branch: codex/fix-billing-e2e-disclosure
+- SDD Spec (JSON, required for non-trivial): N/A (test-only compatibility fix)
+- Created: 2026-08-08
+- Updated: 2026-08-08
+
+## Context
+
+The wallet UX now keeps free-limit details collapsed by default. The billing confidence suite still expected the old expanded state, and the new regression test used a locator whose accessible name changes after disclosure.
+
+## Goal / Acceptance Criteria
+
+- [x] Update existing lead-magnet E2E tests to disclose limits before asserting metrics.
+- [x] Use a stable disclosure locator across the state change.
+- [x] Preserve coverage for collapsed initial state, keyboard disclosure, and visible metrics.
+
+## Non-goals
+
+- No production UI or billing behavior changes.
+- No dependency or CI runner changes.
+
+## Scope (what changes)
+
+- Backend: none.
+- Frontend: none.
+- E2E: update billing wallet and lead-magnet assertions.
+- Config/Env: none.
+
+## Implementation Notes
+
+- Use `button[aria-controls="free-limit-details"]` because its accessible label changes from `Limits` to `Hide limits` after activation.
+- Existing summary tests now explicitly activate the disclosure before checking metric labels.
+
+## Upstream impact
+
+- Upstream-owned files touched: none.
+
+## Verification
+
+- `npx esbuild@0.25.0 e2e/billing_wallet_recovery.spec.ts e2e/billing_lead_magnet.spec.ts --bundle --platform=node --format=esm --external:@playwright/test --outdir=/tmp/billing-e2e-disclosure`
+- `git diff --check`
+- Billing confidence E2E suite (GitHub Actions) after push.
+
+## Risks / Rollback
+
+- Risks: Low; test-only selectors and expectations.
+- Rollback plan: revert the single test commit.
+
+## Completion Checklist
+
+- [x] Branch update entry marked Done.

--- a/meta/memory_bank/specs/work_items/2026-08-08__bugfix__billing-e2e-disclosure-expectations.md
+++ b/meta/memory_bank/specs/work_items/2026-08-08__bugfix__billing-e2e-disclosure-expectations.md
@@ -36,6 +36,7 @@ The wallet UX now keeps free-limit details collapsed by default. The billing con
 
 - Use `button[aria-controls="free-limit-details"]` because its accessible label changes from `Limits` to `Hide limits` after activation.
 - Seed the E2E storage state with denied analytics consent so first-run UI cannot intercept billing interactions.
+- Dismiss the asynchronous release-notes modal during shared E2E setup and wait for the balance response before wallet hero assertions.
 - Existing summary tests now explicitly activate the disclosure before checking metric labels.
 
 ## Upstream impact
@@ -44,7 +45,7 @@ The wallet UX now keeps free-limit details collapsed by default. The billing con
 
 ## Verification
 
-- `npx esbuild@0.25.0 e2e/billing_wallet_recovery.spec.ts e2e/billing_lead_magnet.spec.ts --bundle --platform=node --format=esm --external:@playwright/test --outdir=/tmp/billing-e2e-disclosure`
+- `npx esbuild@0.25.0 e2e/global-setup.ts e2e/billing_wallet_recovery.spec.ts e2e/billing_lead_magnet.spec.ts e2e/billing_wallet.spec.ts --bundle --platform=node --format=esm --external:@playwright/test --outdir=/tmp/billing-e2e-disclosure`
 - `git diff --check`
 - Billing confidence E2E suite (GitHub Actions) after push.
 

--- a/meta/memory_bank/specs/work_items/2026-08-08__bugfix__billing-e2e-disclosure-expectations.md
+++ b/meta/memory_bank/specs/work_items/2026-08-08__bugfix__billing-e2e-disclosure-expectations.md
@@ -35,6 +35,7 @@ The wallet UX now keeps free-limit details collapsed by default. The billing con
 ## Implementation Notes
 
 - Use `button[aria-controls="free-limit-details"]` because its accessible label changes from `Limits` to `Hide limits` after activation.
+- Seed the E2E storage state with denied analytics consent so first-run UI cannot intercept billing interactions.
 - Existing summary tests now explicitly activate the disclosure before checking metric labels.
 
 ## Upstream impact


### PR DESCRIPTION
## Bug
Billing Confidence failed in `e2e_billing_wallet` after the wallet switched to collapsed free-limit details.

## Root cause
Two existing lead-magnet tests still asserted metrics before opening the disclosure. The new regression test located the button by its accessible name, which changes from `Limits` to `Hide limits` after activation.

## Fix
- Explicitly open the free-limit disclosure before metric assertions.
- Use the stable `aria-controls="free-limit-details"` selector across the label change.
- Keep the mobile collapsed-state, keyboard disclosure, and overflow checks.

## Verification
- esbuild syntax validation passed.
- `git diff --check` passed.
- Docker billing confidence E2E will run in CI.
