### PR TITLE
docs(memory): close Airis branding cleanup

### DIFF
--- a/meta/memory_bank/branch_updates/2026-08-08-codex-refactor-airis-brand-cleanup-followup.md
+++ b/meta/memory_bank/branch_updates/2026-08-08-codex-refactor-airis-brand-cleanup-followup.md
@@ -1,10 +1,11 @@
 # Airis branding cleanup follow-up
 
-- [ ] **[REFACTOR]** Close remaining Airis branding residuals
+- [x] **[REFACTOR]** Close remaining Airis branding residuals
   - Spec: `meta/memory_bank/specs/work_items/2026-08-08__refactor__airis-brand-cleanup-followup.md`
   - Owner: Codex
   - Branch: `codex/refactor/airis-brand-cleanup-followup`
   - Started: 2026-08-08
   - Summary: Replace remaining user-visible Open WebUI/WebUI labels with Airis while preserving compatibility and legal identifiers.
-  - Tests: Pending
+  - Tests: Frontend tests passed (32 files, 123 tests); locale JSON/duplicate-key check, `git diff --check`, backend compileall, production image build and null-byte scan passed. Full backend pytest and broad frontend check remain baseline failures documented in PR #109.
   - Risks: Text-only locale key migration; no schema or API contract changes.
+  - Result: PR #109 merged into `airis_b2c`; production deployed as `yshishenya/yshishenya:5ac5a7fd-r1` with PostgreSQL/data backup, Alembic gate passed, and `airis` health verified.

--- a/meta/memory_bank/specs/work_items/2026-08-08__refactor__airis-brand-cleanup-followup.md
+++ b/meta/memory_bank/specs/work_items/2026-08-08__refactor__airis-brand-cleanup-followup.md
@@ -3,7 +3,7 @@
 ## Meta
 
 - Type: refactor
-- Status: active
+- Status: completed
 - Owner: Codex
 - Branch: codex/refactor/airis-brand-cleanup-followup
 - SDD Spec (JSON, required for non-trivial): N/A (mechanical branding cleanup)
@@ -18,11 +18,11 @@ localizations, backend error messages, and outbound user-agent labels.
 
 ## Goal / Acceptance Criteria
 
-- [ ] Replace remaining user-facing Open WebUI/WebUI labels with Airis.
-- [ ] Keep translation keys and values consistent across supported locales.
-- [ ] Preserve compatibility identifiers, package/module names, environment variables,
+- [x] Replace remaining user-facing Open WebUI/WebUI labels with Airis.
+- [x] Keep translation keys and values consistent across supported locales.
+- [x] Preserve compatibility identifiers, package/module names, environment variables,
       headers, MIME types, third-party product names, legal files, and historical records.
-- [ ] Verify the frontend, backend syntax, diff quality, PR, merge, and production health.
+- [x] Verify the frontend, backend syntax, diff quality, PR, merge, and production health.
 
 ## Non-goals
 
@@ -71,6 +71,6 @@ localizations, backend error messages, and outbound user-agent labels.
 
 ## Completion Checklist
 
-- [ ] Branch update entry completed.
-- [ ] PR merged into `airis_b2c`.
-- [ ] Production image deployed and health verified.
+- [x] Branch update entry completed.
+- [x] PR merged into `airis_b2c`.
+- [x] Production image deployed and health verified.


### PR DESCRIPTION
## Summary
- Mark the completed Airis branding cleanup work item and branch update as complete.
- Record verification, merge, backup, and production health evidence.

## Validation
- Documentation diff check passed.
- No runtime or data changes.

## Target
- Base: airis_b2c
- This docs-only PR does not require a production redeploy.