### PR TITLE
fix: preflight Docker Hub deploy credentials

### DIFF
--- a/deploy/targets/prod.env.example
+++ b/deploy/targets/prod.env.example
@@ -4,6 +4,8 @@
 PROD_HOST=185.130.212.71
 PROD_SSH_USER=yan
 PROD_PATH=/opt/projects/open-webui
+# Must be a Docker Hub repository where the build host's PAT has write access.
+# Authenticate once on the build host with: docker login --username <user> docker.io
 IMAGE_REPO=yshishenya/yshishenya
 DOCKER_PLATFORM=linux/amd64
 PROD_SSH_KEY=~/.ssh/airis_prod

--- a/docs/DEPLOY_PROD.md
+++ b/docs/DEPLOY_PROD.md
@@ -2,7 +2,37 @@
 
 This guide describes deploy flow from the dev server to remote targets (`demo`, `prod`).
 The dev server builds and pushes the image to Docker Hub, then triggers a target host
-to pull and restart the container.
+to pull and restart the container. Registry authentication is local to each Docker
+host: a login on prod does not authorize pushes from the dev machine.
+
+## Registry authentication (one-time prerequisite)
+
+The production image repository is `yshishenya/yshishenya` on Docker Hub. The recurring
+`denied: requested access to the resource is denied` error happens when the build host
+has no Docker Hub credential (or the credential has no repository write permission).
+Having a GHCR credential is not enough; registries do not share login sessions.
+
+On the build host, log in once with a Docker Hub access token (PAT), not your account
+password:
+
+```bash
+docker login --username <dockerhub-user> docker.io
+```
+
+The PAT must have write access to the exact repository in `IMAGE_REPO`. Never put the
+token in `.env`, `.env.deploy.*`, shell history, CI logs, or git. The deploy script now
+checks for a matching local credential before spending time on a multi-minute image
+build and prints this remediation when it is missing.
+
+Safe metadata check (prints registry names only, never secrets):
+
+```bash
+docker-credential-desktop list
+```
+
+The output must include Docker Hub (`https://index.docker.io/v1/` or equivalent). If
+the repository is private, an unauthenticated Docker Hub API request may return 404;
+that means “not visible without auth”, not necessarily “repository does not exist”.
 
 ## One-time setup (target servers)
 
@@ -166,12 +196,13 @@ Tagging behavior (when no tag is provided):
 
 What the script does:
 
-1. `docker build` on dev
-2. `docker push` to Docker Hub
-3. `git pull --ff-only` on target (optional, `PROD_GIT_PULL=1`)
-4. `docker compose pull` on target
-5. `docker compose up -d --remove-orphans --no-build` on target
-6. `docker compose ps` on target (optional, `POST_DEPLOY_STATUS=1`)
+1. Verify local registry credentials for `IMAGE_REPO`
+2. `docker build` on dev
+3. `docker push` to Docker Hub
+4. `git pull --ff-only` on target (optional, `PROD_GIT_PULL=1`)
+5. `docker compose pull` on target
+6. `docker compose up -d --remove-orphans --no-build` on target
+7. `docker compose ps` on target (optional, `POST_DEPLOY_STATUS=1`)
 
 ## Guarded production rollout
 
@@ -254,7 +285,12 @@ docker compose down -v
 
 ## Troubleshooting
 
-- Auth error on pull: run `docker login` on prod.
+- `docker push` fails with `denied: requested access to the resource is denied`:
+  - run `docker login --username <dockerhub-user> docker.io` on the build host using a Docker Hub PAT with repository write permission;
+  - verify `IMAGE_REPO` exactly matches the Docker Hub namespace/repository;
+  - do not “fix” this by changing the image repository or copying prod's credential file to the dev machine;
+  - if registry access cannot be restored immediately, use the documented offline/preloaded image flow below and keep the guarded backup/migration/health gates.
+- Auth error on pull: run `docker login` on prod. This is a separate login from the build-host login above.
 - SSH auth error on deploy:
   - Precheck now prints `SSH diagnostic` with the underlying error (DNS/auth/etc.).
   - If you see `Permission denied (publickey,password)`, set `PROD_SSH_KEY=...` in `.env.deploy.<target>.local` or authorize your default SSH key on the target host.

--- a/meta/memory_bank/branch_updates/2026-08-08-codex-fix-dockerhub-push-auth.md
+++ b/meta/memory_bank/branch_updates/2026-08-08-codex-fix-dockerhub-push-auth.md
@@ -1,0 +1,10 @@
+### Done
+
+- [x] **[BUG][DEPLOY][REGISTRY]** Add Docker Hub credential preflight and document the permanent fix
+  - Spec: `meta/memory_bank/specs/work_items/2026-08-08__bugfix__dockerhub-push-auth-preflight.md`
+  - Owner: Codex
+  - Branch: `codex/fix-dockerhub-push-auth`
+  - Done: 2026-08-08
+  - Summary: Root cause was missing Docker Hub credentials on the build host while prod had a separate credential; deploy now fails before build and documents PAT login plus offline fallback.
+  - Tests: bash syntax check; deploy dry-run; safe missing-credential reproduction; git diff check.
+  - Risks: Low; deploy tooling and documentation only.

--- a/meta/memory_bank/specs/work_items/2026-08-08__bugfix__dockerhub-push-auth-preflight.md
+++ b/meta/memory_bank/specs/work_items/2026-08-08__bugfix__dockerhub-push-auth-preflight.md
@@ -1,0 +1,56 @@
+# Docker Hub push authentication preflight
+
+## Meta
+
+- Type: bugfix
+- Status: done
+- Owner: Codex
+- Branch: codex/fix-dockerhub-push-auth
+- SDD Spec (JSON, required for non-trivial): N/A (deployment guard and documentation)
+- Created: 2026-08-08
+- Updated: 2026-08-08
+
+## Context
+
+Production uses the private Docker Hub image `yshishenya/yshishenya`. The build host had only a GHCR credential, so image builds succeeded and the later Docker Hub push failed with `denied: requested access to the resource is denied`. The prod host had its own Docker Hub credential, which does not authenticate the build host.
+
+## Goal / Acceptance Criteria
+
+- [x] Fail before an expensive build when the build host has no credential for the configured registry.
+- [x] Explain the Docker Hub PAT requirement without exposing secrets.
+- [x] Document the one-time login and offline fallback procedures.
+
+## Non-goals
+
+- No registry migration.
+- No credential copying or secret rotation.
+- No production application changes.
+
+## Scope (what changes)
+
+- Backend: none.
+- Frontend: none.
+- Deploy tooling: local registry credential preflight in `scripts/deploy_prod.sh`.
+- Documentation: Docker Hub auth, troubleshooting, and target config guidance.
+
+## Implementation Notes
+
+- Resolve the registry host from `IMAGE_REPO`; unqualified repositories map to Docker Hub.
+- Inspect Docker config auth entries and credential helpers without printing secret values.
+- Skip the preflight for `--dry-run`; real deploys fail closed before `docker build`.
+
+## Verification
+
+- `bash -n scripts/deploy_prod.sh scripts/deploy_guarded.sh scripts/deploy_target.sh`
+- `scripts/deploy_target.sh --target prod --tag 233c097b6 --yes --non-interactive --dry-run`
+- Missing Docker Hub credential reproduced safely: local config exposes only GHCR; preflight reports the remediation before build.
+- `git diff --check`
+
+## Risks / Rollback
+
+- Risks: Low; deploy-only preflight may require a one-time local `docker login` before registry-backed releases.
+- Rollback plan: revert this commit; the existing guarded `--no-pull` offline flow remains available.
+
+## Completion Checklist
+
+- [x] Branch update entry marked Done.

--- a/scripts/deploy_prod.sh
+++ b/scripts/deploy_prod.sh
@@ -432,6 +432,87 @@ run() {
   "$@"
 }
 
+registry_host_from_image() {
+  local image_repo="$1"
+  local host="${image_repo%%/*}"
+
+  if [[ "${host}" != *.* && "${host}" != *:* && "${host}" != "localhost" ]]; then
+    host="docker.io"
+  fi
+  echo "${host}"
+}
+
+registry_server_urls() {
+  local registry_host="$1"
+  if [[ "${registry_host}" == "docker.io" ]]; then
+    printf '%s\n' 'https://index.docker.io/v1/' 'https://registry-1.docker.io' 'docker.io'
+    return 0
+  fi
+  printf 'https://%s\n' "${registry_host}"
+}
+
+has_registry_credentials() {
+  local registry_host="$1"
+  local docker_config="${DOCKER_CONFIG:-${HOME}/.docker}/config.json"
+  local credential_source=""
+  local helper=""
+
+  if [[ ! -f "${docker_config}" ]]; then
+    return 1
+  fi
+
+  credential_source="$(${PYTHON_CMD} - "${docker_config}" "${registry_host}" <<'PY'
+import json
+import sys
+from pathlib import Path
+
+config_path = Path(sys.argv[1])
+registry_host = sys.argv[2].lower().rstrip('/')
+config = json.loads(config_path.read_text(encoding='utf-8'))
+
+aliases = {registry_host}
+if registry_host == 'docker.io':
+    aliases.update({'index.docker.io', 'registry-1.docker.io'})
+
+def matches(value: str) -> bool:
+    normalized = value.lower().rstrip('/')
+    return normalized in aliases or any(
+        normalized.endswith(f'://{alias}') for alias in aliases
+    )
+
+for key, value in config.get('auths', {}).items():
+    if matches(key) and isinstance(value, dict) and (value.get('auth') or value.get('identitytoken')):
+        print('direct')
+        raise SystemExit(0)
+
+for key, value in config.get('credHelpers', {}).items():
+    if matches(key) and value:
+        print(f'helper:{value}')
+        raise SystemExit(0)
+
+if config.get('credsStore'):
+    print(f"helper:{config['credsStore']}")
+PY
+  )" || credential_source=""
+
+  if [[ "${credential_source}" == "direct" ]]; then
+    return 0
+  fi
+  if [[ "${credential_source}" != helper:* ]]; then
+    return 1
+  fi
+
+  helper="docker-credential-${credential_source#helper:}"
+  command -v "${helper}" >/dev/null 2>&1 || return 1
+  while IFS= read -r server_url; do
+    if printf '{"ServerURL":"%s"}' "${server_url}" \
+      | "${helper}" get >/dev/null 2>&1; then
+      return 0
+    fi
+  done < <(registry_server_urls "${registry_host}")
+  return 1
+}
+
 normalize_ssh_key_path() {
   local key_path="$1"
   if [[ "${key_path}" == "~/"* ]]; then
@@ -469,6 +550,22 @@ fi
 q() {
   printf '%q' "$1"
 }
+
+REGISTRY_HOST="$(registry_host_from_image "${IMAGE_REPO}")"
+if [[ "${DRY_RUN}" == "0" ]]; then
+  echo "Checking ${REGISTRY_HOST} credentials..."
+  if ! has_registry_credentials "${REGISTRY_HOST}"; then
+    echo "Registry credentials are missing for ${REGISTRY_HOST}; refusing to build before docker push." >&2
+    if [[ "${REGISTRY_HOST}" == "docker.io" ]]; then
+      echo "Run once on this build host: docker login --username <dockerhub-user> docker.io" >&2
+      echo "Use a Docker Hub PAT with write access to ${IMAGE_REPO}; never store the token in .env or git." >&2
+    else
+      echo "Authenticate this registry on the build host before deploying: docker login ${REGISTRY_HOST}" >&2
+    fi
+    echo "Credentials on the production host do not authenticate this local build host." >&2
+    exit 1
+  fi
+fi
 
 echo "Building ${IMAGE_REPO}:${TAG}..."
 BUILD_ARGS=()


### PR DESCRIPTION
## Context

Docker image builds succeeded locally, but Docker Hub pushes repeatedly failed with `denied: requested access to the resource is denied`. The build host had only a GHCR credential; production has a separate Docker Hub credential for the private `yshishenya/yshishenya` repository.

## Changes

- Add registry-aware credential preflight before the expensive Docker build.
- Detect direct auth entries and Docker credential helpers without printing secrets.
- Document Docker Hub PAT login, repository write scope, host-local auth, and guarded offline fallback.
- Add target config comments and Memory Bank work item/branch update.

## Verification

- `bash -n scripts/deploy_prod.sh scripts/deploy_guarded.sh scripts/deploy_target.sh`
- Deploy dry-run on the merged production config.
- Safe missing-credential reproduction exits before `docker build` with remediation.
- `git diff --check`
- ShellCheck: only pre-existing SC2088 warning.

## Risk

Low: deploy tooling and documentation only. A one-time Docker Hub PAT login remains required on the build host.