### PR TITLE
fix(core): Make YooKassa payer email visible

### DIFF
--- a/backend/open_webui/test/apps/webui/utils/test_billing_service_core.py
+++ b/backend/open_webui/test/apps/webui/utils/test_billing_service_core.py
@@ -10,6 +10,13 @@ from open_webui.utils.billing import BillingService
 
 
 class TestBillingServiceCore:
+    def test_provider_payment_description_contains_email(self) -> None:
+        service = BillingService()
+
+        assert service._provider_payment_description("Top-up wallet 100 RUB", "payer@example.com") == (
+            "Top-up wallet 100 RUB | payer: payer@example.com"
+        )
+
     def test_check_quota_unlimited_without_subscription(self) -> None:
         service = BillingService()
         service.get_user_subscription = lambda *_: None  # type: ignore[method-assign]
@@ -93,10 +100,12 @@ class TestBillingServiceCore:
         class FakeYooKassaClient:
             def __init__(self) -> None:
                 self.metadata: dict[str, object] = {}
+                self.description = ""
                 self.idempotence_key: object = None
 
             async def create_payment(self, **_: object) -> dict[str, object]:
                 self.metadata = dict(_.get("metadata", {}))
+                self.description = str(_.get("description", ""))
                 self.idempotence_key = _.get("idempotence_key")
                 return {
                     "id": "pay_1",
@@ -107,8 +116,8 @@ class TestBillingServiceCore:
         fake_client = FakeYooKassaClient()
         monkeypatch.setattr(billing_utils, "get_yookassa_client", lambda: fake_client)
 
-        async def _resolve_user_email(_user_id: str) -> None:
-            return None
+        async def _resolve_user_email(_user_id: str) -> str:
+            return "payer@example.com"
 
         monkeypatch.setattr(service, "_resolve_user_email", _resolve_user_email)
         # Receipt generation needs a real user/contact in the DB. This unit-style
@@ -141,7 +150,8 @@ class TestBillingServiceCore:
         assert updates[-1][1]["yookassa_payment_id"] == "pay_1"
         assert updates[-1][1]["yookassa_status"] == "pending"
         assert isinstance(fake_client.idempotence_key, str)
-        assert "user_email" not in fake_client.metadata
+        assert fake_client.metadata["user_email"] == "payer@example.com"
+        assert fake_client.description == "Subscription: Pro | payer: payer@example.com"
 
     @pytest.mark.asyncio
     async def test_process_payment_webhook_provider_fetch_failure_is_retryable(

--- a/backend/open_webui/utils/billing.py
+++ b/backend/open_webui/utils/billing.py
@@ -471,6 +471,15 @@ class BillingService:
         user = await Users.get_user_by_id(user_id)
         return self._clean_contact(user.email) if user else None
 
+    @staticmethod
+    def _provider_payment_description(description: str, user_email: Optional[str]) -> str:
+        """Include the payer email in the provider-visible payment description."""
+        if not user_email:
+            return description
+
+        suffix = f" | payer: {user_email}"
+        return f"{description[: max(0, 128 - len(suffix))]}{suffix}"[:128]
+
     async def _build_receipt(
         self,
         user_id: str,
@@ -596,12 +605,13 @@ class BillingService:
         user_email = await self._resolve_user_email(user_id)
         if user_email:
             metadata["user_email"] = user_email
+        provider_description = self._provider_payment_description(transaction.description, user_email)
 
         # Create payment via YooKassa
         payment = await yookassa.create_payment(
             amount=payment_amount,
             currency=plan.currency,
-            description=transaction.description,
+            description=provider_description,
             return_url=return_url,
             metadata=metadata,
             receipt=receipt,
@@ -708,6 +718,7 @@ class BillingService:
         if user_email:
             metadata["user_email"] = user_email
         topup_description = f"Top-up wallet {amount_rub} {BILLING_DEFAULT_CURRENCY}"
+        provider_description = self._provider_payment_description(topup_description, user_email)
         receipt = await self._build_receipt(
             user_id,
             amount_rub,
@@ -726,7 +737,7 @@ class BillingService:
         payment = await yookassa.create_payment(
             amount=amount_rub,
             currency=BILLING_DEFAULT_CURRENCY,
-            description=topup_description,
+            description=provider_description,
             return_url=return_url,
             metadata=metadata,
             receipt=receipt,
@@ -966,6 +977,7 @@ class BillingService:
         if user_email:
             metadata["user_email"] = user_email
         auto_topup_description = f"Auto top-up wallet {amount_rub} {BILLING_DEFAULT_CURRENCY}"
+        provider_description = self._provider_payment_description(auto_topup_description, user_email)
         receipt = await self._build_receipt(
             user_id,
             amount_rub,
@@ -993,7 +1005,7 @@ class BillingService:
             payment = await yookassa.create_payment(
                 amount=amount_rub,
                 currency=BILLING_DEFAULT_CURRENCY,
-                description=auto_topup_description,
+                description=provider_description,
                 metadata=metadata,
                 receipt=receipt,
                 payment_method_id=payment_method_id,

--- a/meta/memory_bank/branch_updates/2026-08-12-codex-bugfix-yookassa-visible-payer-email.md
+++ b/meta/memory_bank/branch_updates/2026-08-12-codex-bugfix-yookassa-visible-payer-email.md
@@ -1,0 +1,10 @@
+### Done — implementation ready for delivery
+
+- [ ] **[BUG][BILLING]** Make payer email visible in YooKassa payment description
+  - Spec: `meta/memory_bank/specs/work_items/2026-08-12__bugfix__yookassa-visible-payer-email.md`
+  - Owner: Codex
+  - Branch: `codex/bugfix/yookassa-visible-payer-email`
+  - Started: 2026-08-12
+  - Summary: Keep email in metadata and add it to the provider-visible description so the payer is identifiable in the YooKassa UI.
+  - Tests: `py_compile` and `git diff --check` passed. Targeted pytest is blocked during collection by the existing SQLite SQLAlchemy configuration (`pool_size`/`pool_timeout` with `NullPool`).
+  - Risks: Email is intentionally visible in YooKassa payment descriptions.

--- a/meta/memory_bank/specs/work_items/2026-08-12__bugfix__yookassa-visible-payer-email.md
+++ b/meta/memory_bank/specs/work_items/2026-08-12__bugfix__yookassa-visible-payer-email.md
@@ -1,0 +1,54 @@
+# YooKassa visible payer email
+
+## Meta
+
+- Type: bugfix
+- Status: completed
+- Owner: Codex
+- Branch: codex/bugfix/yookassa-visible-payer-email
+- SDD Spec (JSON, required for non-trivial): N/A
+- Created: 2026-08-12
+- Updated: 2026-08-12
+
+## Context
+
+Production YooKassa API responses contain `metadata.user_email`, but the YooKassa payment UI does not expose it as the payer field. The email must be visible in the provider payment description as well.
+
+## Goal / Acceptance Criteria
+
+- [x] Include the payer email in the YooKassa-visible payment description for subscription, manual top-up, and auto-top-up payments.
+- [x] Preserve `metadata.user_email` and existing receipt data.
+- [x] Add a regression test for the provider description.
+
+## Non-goals
+
+- No migration or dependency changes.
+- No backfill of existing YooKassa payments.
+
+## Scope (what changes)
+
+- Backend: append a bounded `payer: <email>` suffix to the provider description.
+- Frontend: none.
+
+## Upstream impact
+
+- Upstream-owned files touched: `backend/open_webui/utils/billing.py`.
+- Why unavoidable: all YooKassa payment creation flows share this service.
+- Minimization strategy: one bounded description helper and three call-site substitutions.
+
+## Verification
+
+- `python -m py_compile backend/open_webui/utils/billing.py backend/open_webui/test/apps/webui/utils/test_billing_service_core.py` passed.
+- `git diff --check` passed.
+- Targeted pytest is blocked during collection by the existing SQLite SQLAlchemy configuration (`pool_size`/`pool_timeout` with `NullPool`).
+- Production YooKassa API verification of metadata passed before this follow-up.
+
+## Risks / Rollback
+
+- Risk: account email becomes visible in the YooKassa payment description and potentially to the payer; this is intentional for merchant identification.
+- Rollback: remove the description suffix while keeping metadata if desired.
+
+## Completion Checklist
+
+- [x] Static checks pass; targeted pytest is blocked by the existing environment configuration noted above.
+- [x] Branch update moved to Done.


### PR DESCRIPTION
## Summary

Describe what changed and why.

## Base Branch Policy

- [ ] This PR targets `airis_b2c` (not `main`).

## Workflow Compliance

- [ ] Work item spec is created/updated in `meta/memory_bank/specs/work_items/`.
- [ ] Branch update is appended in `meta/memory_bank/branch_updates/`.
- [ ] For non-trivial changes, SDD spec is linked/updated in `meta/sdd/specs/`.

## Validation

- [ ] Backend checks are green.
- [ ] Frontend checks are green.
- [ ] Migration checks are green (if DB touched).
- [ ] Security checks are green.
- [ ] SDD validation check is green.

## Upstream Impact

List touched upstream-owned files and explain why the change was necessary.

## Summary

- Keep the payer email in YooKassa metadata.
- Append the email to the provider-visible payment description for subscriptions, manual top-ups, and auto top-ups.
- Add regression coverage and document the work item.

## Testing

- python -m py_compile backend/open_webui/utils/billing.py backend/open_webui/test/apps/webui/utils/test_billing_service_core.py
- git diff --check
- Targeted pytest is blocked during collection by the existing SQLite SQLAlchemy configuration (pool_size/pool_timeout with NullPool).
