### PR TITLE
Fix backup-tool build context

### DIFF
--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -39,8 +39,8 @@ services:
     restart: unless-stopped
   backup-tool:
     build:
-      context: .
-      dockerfile: backup-tool/Dockerfile
+      context: ./backup-tool
+      dockerfile: Dockerfile
     env_file:
       - ./.env
       - ./backup-tool/.env


### PR DESCRIPTION
## What changed

- fixed the Docker build context to build directly from the standalone backup-tool checkout
- deployed backup-tool commit 1228e00 with explicit database backup and latest-only remote sync configuration

## Validation

- Compose configuration passed
- backup-tool health check passed
- 17.2G PostgreSQL dump completed
- gzip integrity and local SHA-256 verification passed
- remote sync and remote SHA-256 verification passed
- Open WebUI and PostgreSQL remained healthy