### PR TITLE
Enable Open WebUI archive sync

### DIFF
--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -52,5 +52,6 @@ services:
     extra_hosts:
       - host.docker.internal:host-gateway
     working_dir: /workspace
-    command: ["schedule", "--env", "/workspace/.env", "--project-dir", "/workspace"]
+    entrypoint: ["python", "/workspace/backup-tool/backup-scripts/open_webui_backup.py"]
+    command: ["schedule", "--env", "/workspace/backup-tool/.env", "--project-dir", "/workspace"]
     restart: unless-stopped


### PR DESCRIPTION
Uses the backup-tool Open WebUI adapter to run the existing backup flow and stream open-webui-data as one remotely validated ZIP archive. The archive is never stored locally and atomically overwrites the remote destination.

Validation:
- Docker image build
- backup-tool unit tests
- docker compose config
- end-to-end remote smoke archive and unzip verification