### PR TITLE
Route backup alerts through Telegram relay

### DIFF
--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -44,6 +44,8 @@ services:
     env_file:
       - ./.env
       - ./backup-tool/.env
+    environment:
+      TELEGRAM_PROXY_URL: http://host.docker.internal:18081
     volumes:
       - ./:/workspace
       - /var/run/docker.sock:/var/run/docker.sock


### PR DESCRIPTION
Updates backup-tool to fc288871 with Telegram-only proxy support and kernel flock locks. Configures only TELEGRAM_PROXY_URL for the backup service.

Validation: 12 backup-tool tests, image build, compose config.