### PR TITLE
test(billing): Update wallet E2E headings

### DIFF
--- a/e2e/billing_wallet.spec.ts
+++ b/e2e/billing_wallet.spec.ts
@@ -209,7 +209,7 @@ test.describe('Billing Wallet', () => {
 
 		await page.goto('/billing/balance');
 		await page.waitForResponse('**/api/v1/billing/balance');
-		const heroHeading = page.getByRole('heading', { name: 'Wallet' });
+		const heroHeading = page.getByRole('heading', { name: 'Balance' });
 		await expect(heroHeading).toBeVisible();
 		const heroRow = heroHeading.locator('xpath=../../..');
 		await expect(heroRow.getByRole('button', { name: 'Top up' })).toBeVisible();

--- a/e2e/billing_wallet_recovery.spec.ts
+++ b/e2e/billing_wallet_recovery.spec.ts
@@ -143,11 +143,11 @@ test.describe('Billing wallet recovery (smoke)', () => {
 			await whatsNewCloseButton.first().click();
 		}
 
-		await expect(page.getByRole('heading', { name: 'Wallet' })).toBeVisible();
+		await expect(page.getByRole('heading', { name: 'Balance' })).toBeVisible();
 		await expect(page.getByText('Low balance')).toBeVisible();
 		await expect(page.getByTestId('wallet-low-balance-hint-free')).toBeVisible();
 		await expect(page.getByTestId('wallet-low-balance-free-limit-link')).toBeVisible();
-		const heroHeading = page.getByRole('heading', { name: 'Wallet' });
+		const heroHeading = page.getByRole('heading', { name: 'Balance' });
 		const heroRow = heroHeading.locator('xpath=../../..');
 		await expect(heroRow.getByRole('button', { name: 'Top up' })).toBeVisible();
 


### PR DESCRIPTION
## Context
The merged billing IA cleanup renamed the balance page heading from Wallet to Balance.

## Changes
- Update the two billing E2E specs that assert the old Wallet heading.

## Validation
- `git diff --check` passed.
- The billing confidence workflow will rerun the full backend, frontend, and E2E gate.

## Risk
Test selectors only; no runtime behavior changes.